### PR TITLE
Change timestep implementation, connect model time with real time

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,9 @@ export interface ISimulationConfig {
   gridWidth: number; // ft
   // Spark positions, in ft.
   sparks: number[][];
-  timeStep: number; // minutes
+  maxTimeStep: number; // minutes
+  // One day in model should last X seconds in real world.
+  modelDayInSeconds: number;
   windSpeed: number; // mph
   windDirection: number; // degrees, 0 is northern wind
   moistureContent: number;
@@ -34,7 +36,8 @@ export const defaultConfig: IUrlConfig = {
   modelHeight: 100000,
   gridWidth: 100,
   sparks: [],
-  timeStep: 60, // minutes
+  maxTimeStep: 180, // minutes
+  modelDayInSeconds: 8, // one day in model should last X seconds in real world
   windSpeed: 0, // mph
   windDirection: 0, // degrees, northern wind
   moistureContent: 0.1,

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -219,7 +219,7 @@ export class SimulationModel {
       this.prevTickTime = time;
     }
     if (realTimeDiffInMinutes) {
-      // One day in model time (86400 minutes) should last X seconds in real time.
+      // One day in model time (86400 seconds) should last X seconds in real time.
       const ratio = 86400 / this.config.modelDayInSeconds;
       this.time += Math.min(this.config.maxTimeStep, ratio * realTimeDiffInMinutes);
     } else {

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -70,7 +70,7 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     modelHeight: 25000,
     gridWidth: 100,
     sparks: [ [5000, 12500] ],
-    timeStep: 10,
+    maxTimeStep: 10,
     heightmapMaxElevation: 3000,
     zoneIndex: [
       [ 0, 1 ]


### PR DESCRIPTION
[#169272708]

So it's easy to ensure that one day always lasts around ~8 seconds. This value is configurable via `modelDayInSeconds` URL parameter too. We should stick to this value on most machines unless it's so slow that it reaches `maxTimeStep` value. I picked it arbitrary, perhaps it's possible to increase it in case of need. But 8 seconds per day is actually pretty slow for this model, so I think we're fine for now.