### PR TITLE
Reimplement neighbours calculation so rivers and fire lines are handled correctly + specs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,11 @@ export const defaultConfig: IUrlConfig = {
   windSpeed: 0, // mph
   windDirection: 0, // degrees, northern wind
   moistureContent: 0.07,
-  neighborsDist: 3,
+  // Note that 0.5 helps to create a nicer, more round shape of neighbours set for a given cell
+  // on the rectangular grid when small radius values are used (like 2.5).
+  // 2.5 seems to be first value that ensures that fire front looks pretty round.
+  // Higher values will make this shape better, but performance will be affected.
+  neighborsDist: 2.5,
   cellBurnTime: 2000, // minutes
   heightmapMaxElevation: 3000,
   zonesCount: 2,

--- a/src/models/simulation.test.ts
+++ b/src/models/simulation.test.ts
@@ -1,0 +1,50 @@
+import { getGridCellNeighbors, riverOrFireLineBetween, withinDist } from "./simulation";
+import { Cell } from "./cell";
+
+describe("riverOrFileLineBetween", () => {
+  it("returns true if there's any river or fire line between two points", () => {
+    const cells = [
+      {isRiverOrFireLine: false}, {isRiverOrFireLine: false}, {isRiverOrFireLine: false}, {isRiverOrFireLine: false},
+      {isRiverOrFireLine: false}, {isRiverOrFireLine: false}, {isRiverOrFireLine: false}, {isRiverOrFireLine: false},
+      {isRiverOrFireLine: false}, {isRiverOrFireLine: true}, {isRiverOrFireLine: true}, {isRiverOrFireLine: true},
+      {isRiverOrFireLine: false}, {isRiverOrFireLine: false}, {isRiverOrFireLine: false}, {isRiverOrFireLine: false},
+    ] as Cell[];
+    expect(riverOrFireLineBetween(cells, 4, 0, 0, 0, 3)).toEqual(false);
+    expect(riverOrFireLineBetween(cells, 4, 0, 0, 0, 3)).toEqual(false);
+
+    expect(riverOrFireLineBetween(cells, 4, 1, 0, 0, 3)).toEqual(false);
+    expect(riverOrFireLineBetween(cells, 4, 1, 1, 0, 2)).toEqual(false);
+    expect(riverOrFireLineBetween(cells, 4, 1, 1, 0, 3)).toEqual(true);
+
+    expect(riverOrFireLineBetween(cells, 4, 1, 0, 1, 2)).toEqual(true);
+    expect(riverOrFireLineBetween(cells, 4, 1, 0, 1, 3)).toEqual(true);
+
+    expect(riverOrFireLineBetween(cells, 4, 1, 0, 2, 2)).toEqual(true);
+    expect(riverOrFireLineBetween(cells, 4, 1, 0, 2, 3)).toEqual(true);
+  });
+});
+
+describe("withinDist", () => {
+  it("returns true if dist between point is less or equal than specified max", () => {
+    expect(withinDist(0, 1, 0, 2, 1)).toEqual(true);
+    expect(withinDist(0, 1, 0, 2, 0.9)).toEqual(false);
+    expect(withinDist(0, 0, 1, 1, Math.sqrt(2))).toEqual(true);
+    expect(withinDist(0, 0, 1, 1, Math.sqrt(1.99))).toEqual(false);
+  });
+});
+
+describe("getGridCellNeighbors", () => {
+  it("returns array of neighbours without cells that are rivers, fire lines, or lay behind them", () => {
+    const cells = [
+      {isRiverOrFireLine: false}, {isRiverOrFireLine: false}, {isRiverOrFireLine: false}, {isRiverOrFireLine: false},
+      {isRiverOrFireLine: false}, {isRiverOrFireLine: false}, {isRiverOrFireLine: false}, {isRiverOrFireLine: false},
+      {isRiverOrFireLine: false}, {isRiverOrFireLine: true}, {isRiverOrFireLine: true}, {isRiverOrFireLine: true},
+      {isRiverOrFireLine: false}, {isRiverOrFireLine: false}, {isRiverOrFireLine: false}, {isRiverOrFireLine: false},
+    ] as Cell[];
+    expect(getGridCellNeighbors(cells, 0, 4, 4, 1.5).sort()).toEqual([1, 4, 5]);
+    expect(getGridCellNeighbors(cells, 5, 4, 4, 1.5).sort()).toEqual([0, 1, 2, 4, 6, 8]);
+    expect(getGridCellNeighbors(cells, 5, 4, 4, 2.5).sort()).toEqual([0, 1, 12, 2, 3, 4, 6, 7, 8]);
+    expect(getGridCellNeighbors(cells, 14, 4, 4, 2.5).sort()).toEqual([12, 13, 15]);
+    expect(getGridCellNeighbors(cells, 15, 4, 4, 2.5).sort()).toEqual([13, 14]);
+  });
+});


### PR DESCRIPTION
[#169293104]

This new approach uses BFS to find neighbors of a given cell. Compared to two nested loops that were used previously:
1. We can detect at some point that a the river or fire line is one of the neighbors and start using Bresenham's algorithm later on (more about that below).
2. We can create a more round shape of the neighbors set (by using `withinDist` function), so we have fewer neighbors in the end and simulation can start faster.

To handle rivers and fire lines, I've added Bresenham's algorithm which checks if there's any river or fire lines cell between two provided coordinates. That should prevent jumping fire across rivers. `anyRiverOrFireLine` is just an optimization.

The neighbor calculation might look complex now, but actually it's still much less time-consuming than ignition time calculations. I've added `console.time` calls so we can test that on Chrombooks easier.

I've also adjusted `neighborDist` value, so the firefront is still reasonably round, but we process much fewer neighbors per cell (together with a new algorithm). Hopefully, that should speed up startup time on Chrombooks too.

This works well for rivers, but things will get more complicated when we have dynamic fire lines. I haven't thought about that yet, but I'm hoping we can recalculate only part of the grid around the fireline.

@sfentress, I'm not marking you as a reviewer, but if you have some time, ofc it'd be great if you can take a look or share some thoughts (as you mentioned this issue today).