### PR TITLE
Cleanup (mostly elevation data loading, terrain panel, and presets)

### DIFF
--- a/src/components/terrain-panel.test.tsx
+++ b/src/components/terrain-panel.test.tsx
@@ -4,40 +4,41 @@ import { createStores } from "../models/stores";
 import { Provider } from "mobx-react";
 import { TerrainPanel } from "./terrain-panel";
 import { Slider } from "@material-ui/core";
+import { LandType, TerrainType } from "../models/fire-model";
 
 const defaultTwoZones = [
   {
-    landType: 2,
+    landType: LandType.ForestSmallLitter,
     moistureContent: 0.07,
     droughtLevel: 2,
-    terrainType: 0
+    terrainType: TerrainType.Mountains
   },
   {
-    landType: 1,
+    landType: LandType.Shrub,
     moistureContent: 0.14,
     droughtLevel: 1,
-    terrainType: 2
+    terrainType: TerrainType.Plains
   }
 ];
 
 const defaultThreeZones = [
   {
-    landType: 2,
+    landType: LandType.ForestSmallLitter,
     moistureContent: 0.07,
     droughtLevel: 2,
-    terrainType: 0
+    terrainType: TerrainType.Mountains
   },
   {
-    landType: 1,
+    landType: LandType.Shrub,
     moistureContent: 0.14,
     droughtLevel: 1,
-    terrainType: 2
+    terrainType: TerrainType.Plains
   },
   {
-    landType: 3,
+    landType: LandType.ForestLargeLitter,
     moistureContent: 0.21,
     droughtLevel: 0,
-    terrainType: 1
+    terrainType: TerrainType.Foothills
   },
 ];
 
@@ -118,8 +119,8 @@ describe("vegetation selector", () => {
       </Provider>
     );
     expect(wrapper.find(Slider)).toHaveLength(2);
-
   });
+
   it("displays the correct vegetation level", () => {
     const wrapper = mount(
       <Provider stores={stores}>
@@ -138,6 +139,7 @@ describe("vegetation selector", () => {
     // veg = wrapper.find('[data-test="vegetation-slider"]').first();
     // expect(veg.prop("value")).toBe(1);
   });
+
   it("displays the correct drought level", () => {
     const wrapper = mount(
       <Provider stores={stores}>

--- a/src/components/terrain-panel.test.tsx
+++ b/src/components/terrain-panel.test.tsx
@@ -4,17 +4,17 @@ import { createStores } from "../models/stores";
 import { Provider } from "mobx-react";
 import { TerrainPanel } from "./terrain-panel";
 import { Slider } from "@material-ui/core";
-import { LandType, TerrainType } from "../models/fire-model";
+import { Vegetation, TerrainType } from "../models/fire-model";
 
 const defaultTwoZones = [
   {
-    landType: LandType.ForestSmallLitter,
+    vegetation: Vegetation.ForestSmallLitter,
     moistureContent: 0.07,
     droughtLevel: 2,
     terrainType: TerrainType.Mountains
   },
   {
-    landType: LandType.Shrub,
+    vegetation: Vegetation.Shrub,
     moistureContent: 0.14,
     droughtLevel: 1,
     terrainType: TerrainType.Plains
@@ -23,19 +23,19 @@ const defaultTwoZones = [
 
 const defaultThreeZones = [
   {
-    landType: LandType.ForestSmallLitter,
+    vegetation: Vegetation.ForestSmallLitter,
     moistureContent: 0.07,
     droughtLevel: 2,
     terrainType: TerrainType.Mountains
   },
   {
-    landType: LandType.Shrub,
+    vegetation: Vegetation.Shrub,
     moistureContent: 0.14,
     droughtLevel: 1,
     terrainType: TerrainType.Plains
   },
   {
-    landType: LandType.ForestLargeLitter,
+    vegetation: Vegetation.ForestLargeLitter,
     moistureContent: 0.21,
     droughtLevel: 0,
     terrainType: TerrainType.Foothills

--- a/src/components/terrain-panel.tsx
+++ b/src/components/terrain-panel.tsx
@@ -6,7 +6,7 @@ import { renderZones } from "./zone-selector";
 import { TerrainTypeSelector } from "./terrain-type-selector";
 import { VegetationSelector } from "./vegetation-selector";
 import { DroughtSelector } from "./drought-selector";
-import { TerrainType, LandType } from "../models/fire-model";
+import { TerrainType, Vegetation } from "../models/fire-model";
 import { WindCircularControl } from "./wind-circular-control";
 import { TerrainSummary } from "./terrain-summary";
 
@@ -41,7 +41,7 @@ export class TerrainPanel extends BaseComponent<IProps, IState> {
     const { selectedZone, currentPanel } = this.state;
     const zone = simulation.zones[selectedZone];
     const displayVegetationType =
-      zone.terrainType === TerrainType.Mountains ? zone.landType - 1 : zone.landType;
+      zone.terrainType === TerrainType.Mountains ? zone.vegetation - 1 : zone.vegetation;
     const panelClass = currentPanel === 1 ? css.panel1 : css.panel2;
     const panelInstructions = currentPanel === 1 ? "Adjust variables in each zone" : "Set initial wind direction and speed";
     return (
@@ -76,7 +76,7 @@ export class TerrainPanel extends BaseComponent<IProps, IState> {
               <div className={css.selectors}>
                 <div className={css.selector}>
                   <VegetationSelector
-                    landType={displayVegetationType}
+                    vegetation={displayVegetationType}
                     terrainType={zone.terrainType}
                     onChange={this.handleVegetationChange} />
                 </div>
@@ -147,12 +147,12 @@ export class TerrainPanel extends BaseComponent<IProps, IState> {
       // Switching to Mountain terrain changes land type / vegetation options
       // but keeping the min / max options the same for each range helps with slider rendering.
       // Accommodate this by manual adjustment of land types when switching to-from mountain
-      if (newTerrainType !== TerrainType.Mountains && currentZone.landType === LandType.ForestLargeLitter) {
+      if (newTerrainType !== TerrainType.Mountains && currentZone.vegetation === Vegetation.ForestLargeLitter) {
         // switching from Mountains with large forests to lower land type, reduce forest size
-        simulation.updateZoneVegetation(this.state.selectedZone, LandType.ForestSmallLitter);
-      } else if (newTerrainType === TerrainType.Mountains && currentZone.landType === LandType.Grass) {
+        simulation.updateZoneVegetation(this.state.selectedZone, Vegetation.ForestSmallLitter);
+      } else if (newTerrainType === TerrainType.Mountains && currentZone.vegetation === Vegetation.Grass) {
         // no grass allowed on mountains, switch to shrubs
-        simulation.updateZoneVegetation(this.state.selectedZone, LandType.Shrub);
+        simulation.updateZoneVegetation(this.state.selectedZone, Vegetation.Shrub);
       }
       simulation.updateZoneTerrain(this.state.selectedZone, newTerrainType);
     }
@@ -193,7 +193,7 @@ export class TerrainPanel extends BaseComponent<IProps, IState> {
     simulation.zones.forEach((z, i) => {
       if (i < config.zonesCount) {
         labels.push(
-          <TerrainSummary vegetationType={z.landType} droughtLevel={z.droughtLevel} key={i} />
+          <TerrainSummary vegetationType={z.vegetation} droughtLevel={z.droughtLevel} key={i} />
         );
       }
     });

--- a/src/components/terrain-panel.tsx
+++ b/src/components/terrain-panel.tsx
@@ -2,17 +2,15 @@ import { inject, observer } from "mobx-react";
 import React from "react";
 import { BaseComponent, IBaseProps } from "./base";
 import { Button } from "@material-ui/core";
-
 import { renderZones } from "./zone-selector";
 import { TerrainTypeSelector } from "./terrain-type-selector";
 import { VegetationSelector } from "./vegetation-selector";
 import { DroughtSelector } from "./drought-selector";
-
-import css from "./terrain-panel.scss";
 import { TerrainType, LandType } from "../models/fire-model";
-import { WindControls } from "./wind-controls";
 import { WindCircularControl } from "./wind-circular-control";
 import { TerrainSummary } from "./terrain-summary";
+
+import css from "./terrain-panel.scss";
 
 interface IProps extends IBaseProps {}
 interface IState {
@@ -69,7 +67,7 @@ export class TerrainPanel extends BaseComponent<IProps, IState> {
                 {config.zonesCount > 2 && simulation.zones.length > 2 &&
                   <div className={css.terrainTypeLabels}>{this.renderZoneTerrainTypeLabels()}</div>
                 }
-                {config.zonesCount === 2 &&
+                {!config.elevation && config.zonesCount === 2 &&
                   <TerrainTypeSelector
                     terrainType={zone.terrainType}
                     onChange={this.handleTerrainTypeChange} />
@@ -118,27 +116,11 @@ export class TerrainPanel extends BaseComponent<IProps, IState> {
     const { ui } = this.stores;
     ui.showTerrainUI = !ui.showTerrainUI;
   }
-  public applyAndClose = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    // trigger re-draw of terrain
-    const { ui, simulation, simulation: { config } } = this.stores;
+
+  public applyAndClose = () => {
+    const { ui, simulation } = this.stores;
     ui.showTerrainUI = !ui.showTerrainUI;
-    // check if elevation has changed since last update
-    const prefix = "data/";
-    const zoneTypes: string[] = [];
-    simulation.zones.forEach((z, i) => {
-      if (i < config.zonesCount) {
-        zoneTypes.push(TerrainType[z.terrainType].toLowerCase());
-      }
-    });
-    const edgeStyle = config.fillTerrainEdges ? "-edge" : "";
-    const newElevation = prefix + zoneTypes.join("-") + "-heightmap" + edgeStyle + ".png";
-    if (config.elevation !== newElevation) {
-      // force a redraw of terrain when this flips to true
-      simulation.dataReady = false;
-      config.elevation = newElevation;
-    }
-    // If simulation was not Ready then this will mark it as such.
-    simulation.restart();
+    simulation.populateCellsData();
   }
 
   public handleZoneChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -148,10 +130,12 @@ export class TerrainPanel extends BaseComponent<IProps, IState> {
       this.setState({ selectedZone: newZone });
     }
   }
-  public showNextPanel = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+
+  public showNextPanel = () => {
     this.setState({ currentPanel: 2 });
   }
-  public showPreviousPanel = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+
+  public showPreviousPanel = () => {
     this.setState({ currentPanel: 1 });
   }
 
@@ -163,12 +147,10 @@ export class TerrainPanel extends BaseComponent<IProps, IState> {
       // Switching to Mountain terrain changes land type / vegetation options
       // but keeping the min / max options the same for each range helps with slider rendering.
       // Accommodate this by manual adjustment of land types when switching to-from mountain
-      if (currentZone.terrainType === TerrainType.Mountains &&
-        currentZone.landType === LandType.ForestLargeLitter) {
+      if (newTerrainType !== TerrainType.Mountains && currentZone.landType === LandType.ForestLargeLitter) {
         // switching from Mountains with large forests to lower land type, reduce forest size
         simulation.updateZoneVegetation(this.state.selectedZone, LandType.ForestSmallLitter);
-      }
-      else if (newTerrainType === TerrainType.Mountains && currentZone.landType === LandType.Grass) {
+      } else if (newTerrainType === TerrainType.Mountains && currentZone.landType === LandType.Grass) {
         // no grass allowed on mountains, switch to shrubs
         simulation.updateZoneVegetation(this.state.selectedZone, LandType.Shrub);
       }
@@ -178,22 +160,14 @@ export class TerrainPanel extends BaseComponent<IProps, IState> {
 
   public handleVegetationChange = (event: React.ChangeEvent<HTMLInputElement>, value: number) => {
     const { simulation } = this.stores;
-    const zone = Object.assign({}, simulation.zones[this.state.selectedZone]);
-    const displayVegetationType =
-      zone.terrainType === TerrainType.Mountains ? zone.landType - 1 : zone.landType;
-
-    if (displayVegetationType !== value) {
-      const newVegetationType =
-        zone.terrainType === TerrainType.Mountains ? value + 1 : value;
-      simulation.updateZoneVegetation(this.state.selectedZone, newVegetationType);
-    }
+    const zone = simulation.zones[this.state.selectedZone];
+    const newVegetationType = zone.terrainType === TerrainType.Mountains ? value + 1 : value;
+    simulation.updateZoneVegetation(this.state.selectedZone, newVegetationType);
   }
+
   public handleDroughtChange = (event: React.ChangeEvent<HTMLInputElement>, value: number) => {
     const { simulation } = this.stores;
-    const currentZone = Object.assign({}, simulation.zones[this.state.selectedZone]);
-    if (currentZone.droughtLevel !== value) {
-      simulation.updateZoneMoisture(this.state.selectedZone, value);
-    }
+    simulation.updateZoneMoisture(this.state.selectedZone, value);
   }
 
   private renderZoneTerrainTypeLabels = () => {
@@ -211,6 +185,7 @@ export class TerrainPanel extends BaseComponent<IProps, IState> {
     });
     return labels;
   }
+
   private renderTerrainProperties = () => {
     const { simulation, simulation: { config }  } = this.stores;
     const labels: any[] = [];

--- a/src/components/vegetation-selector.tsx
+++ b/src/components/vegetation-selector.tsx
@@ -7,7 +7,7 @@ import * as css from "./vertical-selectors.scss";
 import { vegetationLabels, generateMarks, vegetationIcons } from "./vertical-selectors";
 
 interface IProps {
-  landType: number;
+  vegetation: number;
   terrainType: number;
   onChange?: any;
 }
@@ -23,7 +23,7 @@ const icons = [
   <div className={`${css.sliderIcon} ${css.fsl} ${css.top} ${css.placeholder}`} key={2}>{vegetationIcons[2]}</div>
 ];
 
-export const VegetationSelector = ({ landType: vegetationType, terrainType, onChange }: IProps) =>
+export const VegetationSelector = ({ vegetation: vegetationType, terrainType, onChange }: IProps) =>
   (
     <div className={`${css.selector} ${css.vegetation}`}>
       <div className={css.header}>Vegetation Type</div>

--- a/src/components/view-3d/terrain.tsx
+++ b/src/components/view-3d/terrain.tsx
@@ -5,21 +5,21 @@ import { useThree } from "../../react-three-hook";
 import { observer } from "mobx-react";
 import { useStores } from "../../use-stores";
 import { Cell, FireState } from "../../models/cell";
-import { LandType } from "../../models/fire-model";
 import { SimulationModel } from "../../models/simulation";
 import { IThreeContext } from "../../react-three-hook/threejs-manager";
 import { ftToViewUnit, PLANE_WIDTH, planeHeight } from "./helpers";
 import { SparksContainer } from "./spark";
 import { Interaction } from "../../models/ui";
 import { AddSparkInteraction } from "./add-spark-interaction";
+import { DroughtLevel } from "../../models/fire-model";
 
 const getTerrainColor = (droughtLevel: number) => {
   switch (droughtLevel) {
-    case 0:
+    case DroughtLevel.NoDrought:
       return [0.008, 0.831, 0.039, 1];
-    case 1:
+    case DroughtLevel.MildDrought:
       return [0.573, 0.839, 0.216, 1];
-    case 2:
+    case DroughtLevel.MediumDrought:
       return [0.757, 0.886, 0.271, 1];
     default:
       return [0.784, 0.631, 0.271, 1];
@@ -95,17 +95,17 @@ export const Terrain = observer(() => {
 
   useEffect(() => {
     const plane = getEntity();
-    if (plane && simulation.dataReady) {
+    if (plane) {
       setupElevation(plane, simulation);
     }
-  }, [simulation.dataReady]);
+  }, [simulation.cellsElevationFlag]);
 
   useEffect(() => {
     const plane = getEntity();
     if (plane) {
       updateColors(plane, simulation);
     }
-  }, [simulation.cells]);
+  }, [simulation.cellsStateFlag]);
 
   // Note that we don't want to conditionally render <PlaceSparkInteraction> or provide more props to it.
   // If <PlaceSparkInteraction> subscribes to stores directly, we can avoid unnecessary re-renders of parent component

--- a/src/components/zone-selector.tsx
+++ b/src/components/zone-selector.tsx
@@ -78,7 +78,7 @@ export const renderZones = (
               </span>
               {!readonly &&
                 <span className={`${css.vegetationPreview} ${i > 0 ? vegPreviewPosition : ""}`}>
-                  {vegetationIcons[z.landType]}</span>
+                  {vegetationIcons[z.vegetation]}</span>
               }
             </div>
           </label>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { ZoneOptions } from "./models/zone";
-import { LandType } from "./models/fire-model";
+import { DroughtLevel, LandType, TerrainType } from "./models/fire-model";
 
 export interface ISimulationConfig {
   modelWidth: number; // ft
@@ -51,9 +51,9 @@ export const defaultConfig: IUrlConfig = {
   heightmapMaxElevation: 3000,
   zonesCount: 2,
   zones: [
-    { landType: LandType.Grass, moistureContent: 0 },
-    { landType: LandType.Shrub, moistureContent: 0.07 },
-    { landType: LandType.Grass, moistureContent: 0.21 }
+    { terrainType: TerrainType.Plains, landType: LandType.Grass, droughtLevel: DroughtLevel.MildDrought },
+    { terrainType: TerrainType.Plains, landType: LandType.Shrub, droughtLevel: DroughtLevel.MediumDrought },
+    { terrainType: TerrainType.Plains, landType: LandType.ForestSmallLitter, droughtLevel: DroughtLevel.SevereDrought }
   ],
   fillTerrainEdges: true
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { ZoneOptions } from "./models/zone";
-import { DroughtLevel, LandType, TerrainType } from "./models/fire-model";
+import { DroughtLevel, Vegetation, TerrainType } from "./models/fire-model";
 
 export interface ISimulationConfig {
   modelWidth: number; // ft
@@ -52,9 +52,21 @@ export const defaultConfig: IUrlConfig = {
   heightmapMaxElevation: 20000,
   zonesCount: 2,
   zones: [
-    { terrainType: TerrainType.Plains, landType: LandType.Grass, droughtLevel: DroughtLevel.MildDrought },
-    { terrainType: TerrainType.Plains, landType: LandType.Shrub, droughtLevel: DroughtLevel.MediumDrought },
-    { terrainType: TerrainType.Plains, landType: LandType.ForestSmallLitter, droughtLevel: DroughtLevel.SevereDrought }
+    {
+      terrainType: TerrainType.Plains,
+      vegetation: Vegetation.Grass,
+      droughtLevel: DroughtLevel.MildDrought
+    },
+    {
+      terrainType: TerrainType.Plains,
+      vegetation: Vegetation.Shrub,
+      droughtLevel: DroughtLevel.MediumDrought
+    },
+    {
+      terrainType: TerrainType.Plains,
+      vegetation: Vegetation.ForestSmallLitter,
+      droughtLevel: DroughtLevel.SevereDrought
+    }
   ],
   fillTerrainEdges: true,
   riverData: "data/river-texmap-data.png"

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,7 +48,7 @@ export const defaultConfig: IUrlConfig = {
   // Higher values will make this shape better, but performance will be affected.
   neighborsDist: 2.5,
   cellBurnTime: 2000, // minutes
-  heightmapMaxElevation: 3000,
+  heightmapMaxElevation: 20000,
   zonesCount: 2,
   zones: [
     { terrainType: TerrainType.Plains, landType: LandType.Grass, droughtLevel: DroughtLevel.MildDrought },

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,7 @@ export interface ISimulationConfig {
   zonesCount: 2 | 3;
   zones: [ZoneOptions, ZoneOptions, ZoneOptions?];
   fillTerrainEdges: boolean;
+  riverData: string | null;
 }
 
 export interface IUrlConfig extends ISimulationConfig {
@@ -55,7 +56,8 @@ export const defaultConfig: IUrlConfig = {
     { terrainType: TerrainType.Plains, landType: LandType.Shrub, droughtLevel: DroughtLevel.MediumDrought },
     { terrainType: TerrainType.Plains, landType: LandType.ForestSmallLitter, droughtLevel: DroughtLevel.SevereDrought }
   ],
-  fillTerrainEdges: true
+  fillTerrainEdges: true,
+  riverData: "data/river-texmap-data.png"
 };
 
 export const urlConfig: any = {};

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -29,8 +29,8 @@ export class Cell {
     Object.assign(this, props);
   }
 
-  public get landType() {
-    return this.zone.landType;
+  public get vegetation() {
+    return this.zone.vegetation;
   }
 
   public get moistureContent() {

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -37,11 +37,16 @@ export class Cell {
     if (!this.isRiverOrFireLine) {
       return this.zone.moistureContent;
     } else {
-      return 10000;
+      return Infinity;
     }
   }
 
   public get droughtLevel() {
     return this.zone.droughtLevel;
+  }
+
+  public reset() {
+    this.ignitionTime = Infinity;
+    this.fireState = FireState.Unburnt;
   }
 }

--- a/src/models/fire-model.test.ts
+++ b/src/models/fire-model.test.ts
@@ -1,11 +1,11 @@
-import { getFireSpreadRate, LandType, getDirectionFactor } from "./fire-model";
+import { getFireSpreadRate, Vegetation, getDirectionFactor } from "./fire-model";
 
 const cellSize = 1;
 
 const sourceCell = {
   x: 10,
   y: 11,
-  landType: LandType.Shrub,
+  vegetation: Vegetation.Shrub,
   moistureContent: 0.1,
   elevation: 0,
   isRiverOrFireLine: false
@@ -14,7 +14,7 @@ const sourceCell = {
 const targetCell = {
   x: 10,
   y: 10,
-  landType: LandType.Shrub,
+  vegetation: Vegetation.Shrub,
   moistureContent: 0.1,
   // Why such elevation? Note that spreadsheet uses value for slope -1deg => Math.PI / 180.
   // Ensure that we use the same slope here (so calculate elevation accordingly).

--- a/src/models/fire-model.ts
+++ b/src/models/fire-model.ts
@@ -1,7 +1,7 @@
 import { Fuel } from "../types";
 import { Vector2 } from "three";
 
-export enum LandType {
+export enum Vegetation {
   Grass = 0,
   Shrub = 1,
   ForestSmallLitter = 2,
@@ -30,14 +30,14 @@ export interface IWindProps {
 export interface ICellProps {
   x: number;
   y: number;
-  landType: LandType;
+  vegetation: Vegetation;
   moistureContent: number;
   elevation: number;
   isRiverOrFireLine: boolean;
 }
 
-const FuelConstants: {[key in LandType]: Fuel} = {
-  [LandType.Grass]: {
+const FuelConstants: {[key in Vegetation]: Fuel} = {
+  [Vegetation.Grass]: {
     sav: 1826,
     packingRatio: 0.00154,
     netFuelLoad: 0.09871442,
@@ -47,7 +47,7 @@ const FuelConstants: {[key in LandType]: Fuel} = {
     effectiveMineralContent: 0.01,
     fuelBedDepth: 1
   },
-  [LandType.Shrub]: {
+  [Vegetation.Shrub]: {
     sav: 1144,
     packingRatio: 0.00412,
     netFuelLoad: 0.183655,
@@ -59,7 +59,7 @@ const FuelConstants: {[key in LandType]: Fuel} = {
   },
   // TODO: the following two land types have not yet been configured via specification,
   // only by approximation to get the code to compile
-  [LandType.ForestSmallLitter]: {
+  [Vegetation.ForestSmallLitter]: {
     sav: 800,
     packingRatio: 0.00812,
     netFuelLoad: 0.383655,
@@ -69,7 +69,7 @@ const FuelConstants: {[key in LandType]: Fuel} = {
     effectiveMineralContent: 0.01,
     fuelBedDepth: 3
   },
-  [LandType.ForestLargeLitter]: {
+  [Vegetation.ForestLargeLitter]: {
     sav: 600,
     packingRatio: 0.01412,
     netFuelLoad: 0.583655,
@@ -155,7 +155,7 @@ export const getFireSpreadRate = (
 ) => {
   // small tweak to prevent the extreme edges of the simulation from burning
   if (targetCell.x < 2 || targetCell.y < 2 || targetCell.x > gridWidth - 3 || targetCell.y > gridHeight - 3) return 0;
-  const fuel = FuelConstants[targetCell.landType];
+  const fuel = FuelConstants[targetCell.vegetation];
   const sav = fuel.sav;
   const packingRatio = fuel.packingRatio;
   const netFuelLoad = fuel.netFuelLoad;

--- a/src/models/fire-model.ts
+++ b/src/models/fire-model.ts
@@ -1,5 +1,4 @@
 import { Fuel } from "../types";
-import {Cell} from "./cell";
 import { Vector2 } from "three";
 
 export enum LandType {
@@ -9,9 +8,9 @@ export enum LandType {
   ForestLargeLitter = 3
 }
 export enum TerrainType {
-  Mountains = 0,
+  Plains = 0,
   Foothills = 1,
-  Plains = 2
+  Mountains = 2
 }
 export enum DroughtLevel {
   NoDrought = 0,

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -1,5 +1,5 @@
 import { action, observable, computed } from "mobx";
-import { getFireSpreadRate, IWindProps, LandType, TerrainType, DroughtLevel, moistureLookups } from "./fire-model";
+import { getFireSpreadRate, IWindProps, LandType, TerrainType, DroughtLevel } from "./fire-model";
 import { Cell, CellOptions, FireState } from "./cell";
 import { urlConfig, defaultConfig } from "../config";
 import { IPresetConfig } from "../presets";
@@ -156,10 +156,6 @@ export class SimulationModel {
     this.gridWidth = config.gridWidth;
     this.gridHeight = Math.ceil(config.modelHeight / this.cellSize);
     this.zones = config.zones.map(options => new Zone(options!));
-    // set moisture values per-zone based on drought level and vegetation
-    this.zones.forEach((z) => {
-      z.moistureContent = moistureLookups[z.droughtLevel][z.landType];
-    });
     this.populateCellsData();
     this.setInputParamsFromConfig();
 
@@ -350,15 +346,10 @@ export class SimulationModel {
   }
 
   @action.bound public updateZoneMoisture(zoneIdx: number, droughtLevel: DroughtLevel) {
-    // moisture content from lookup of drought level and land type
-    const zone = this.zones[zoneIdx];
-    this.zones[zoneIdx].moistureContent = moistureLookups[droughtLevel][zone.landType];
     this.zones[zoneIdx].droughtLevel = droughtLevel;
   }
 
   @action.bound public updateZoneVegetation(zoneIdx: number, vegetation: LandType) {
-    const zone = this.zones[zoneIdx];
-    this.zones[zoneIdx].moistureContent = moistureLookups[zone.droughtLevel][vegetation];
     this.zones[zoneIdx].landType = vegetation;
   }
 

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -1,5 +1,5 @@
 import { action, computed, observable } from "mobx";
-import { DroughtLevel, getFireSpreadRate, IWindProps, LandType, TerrainType } from "./fire-model";
+import { DroughtLevel, getFireSpreadRate, IWindProps, Vegetation, TerrainType } from "./fire-model";
 import { Cell, CellOptions, FireState } from "./cell";
 import { defaultConfig, urlConfig } from "../config";
 import { IPresetConfig } from "../presets";
@@ -370,8 +370,8 @@ export class SimulationModel {
     this.zones[zoneIdx].droughtLevel = droughtLevel;
   }
 
-  @action.bound public updateZoneVegetation(zoneIdx: number, vegetation: LandType) {
-    this.zones[zoneIdx].landType = vegetation;
+  @action.bound public updateZoneVegetation(zoneIdx: number, vegetation: Vegetation) {
+    this.zones[zoneIdx].vegetation = vegetation;
   }
 
   public canAddSpark() {

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -1,7 +1,7 @@
-import { action, observable, computed } from "mobx";
-import { getFireSpreadRate, IWindProps, LandType, TerrainType, DroughtLevel } from "./fire-model";
+import { action, computed, observable } from "mobx";
+import { DroughtLevel, getFireSpreadRate, IWindProps, LandType, TerrainType } from "./fire-model";
 import { Cell, CellOptions, FireState } from "./cell";
-import { urlConfig, defaultConfig } from "../config";
+import { defaultConfig, urlConfig } from "../config";
 import { IPresetConfig } from "../presets";
 import { getInputData } from "../utils";
 import { Vector2 } from "three";
@@ -134,8 +134,6 @@ export class SimulationModel {
   public prevTickTime: number | null;
   @observable public dataReady = false;
   @observable public wind: IWindProps;
-  // TODO: This may be used later for Rain, for now, simulation should use moisture per-zone
-  @observable public moistureContent: number;
   @observable public sparks: Vector2[] = [];
   @observable public cellSize: number;
   @observable public gridWidth: number;
@@ -145,6 +143,11 @@ export class SimulationModel {
   @observable public cells: Cell[] = [];
   @observable public simulationStarted = false;
   @observable public simulationRunning = false;
+  // These flags can be used by view to trigger appropriate rendering. Theoretically, view could/should check
+  // every single cell and re-render when it detects some changes. In practice, we perform these updates in very
+  // specific moments and usually for all the cells, so this approach can be way more efficient.
+  @observable public cellsStateFlag = 0;
+  @observable public cellsElevationFlag = 0;
 
   constructor(presetConfig: Partial<IPresetConfig>) {
     // Configuration are joined together. Default values can be replaced by preset, and preset values can be replaced
@@ -173,7 +176,6 @@ export class SimulationModel {
       speed: config.windSpeed,
       direction: config.windDirection
     };
-    this.moistureContent = config.moistureContent;
     this.sparks.length = 0;
     config.sparks.forEach(s => {
       this.addSpark(s[0], s[1]);
@@ -196,7 +198,21 @@ export class SimulationModel {
   }
 
   public getElevationData(): Promise<number[] | undefined> {
-    return getInputData(this.config.elevation, this.gridWidth, this.gridHeight, true,
+    // If `elevation` height map is provided, it will be loaded during model initialization.
+    // Otherwise, height map URL will be derived from zones `terrainType` properties.
+    let heightmapUrl = this.config.elevation;
+    if (!heightmapUrl) {
+      const prefix = "data/";
+      const zoneTypes: string[] = [];
+      this.zones.forEach((z, i) => {
+        if (i < this.config.zonesCount) {
+          zoneTypes.push(TerrainType[z.terrainType].toLowerCase());
+        }
+      });
+      const edgeStyle = this.config.fillTerrainEdges ? "-edge" : "";
+      heightmapUrl = prefix + zoneTypes.join("-") + "-heightmap" + edgeStyle + ".png";
+    }
+    return getInputData(heightmapUrl, this.gridWidth, this.gridHeight, true,
       (rgba: [number, number, number, number]) => {
         // Elevation data is supposed to black & white image, where black is the lowest point and
         // white is the highest.
@@ -215,6 +231,7 @@ export class SimulationModel {
   }
 
   @action.bound public populateCellsData() {
+    this.dataReady = false;
     Promise.all([this.getZoneIndex(), this.getElevationData(), this.getRiverData()]).then(values => {
       const zoneIndex = values[0];
       const elevation = values[1];
@@ -226,7 +243,8 @@ export class SimulationModel {
         for (let x = 0; x < this.gridWidth; x++) {
           const index = getGridIndexForLocation(x, y, this.gridWidth);
           const cellOptions: CellOptions = {
-            x, y, zone: this.zones[zoneIndex ? zoneIndex[index] : 0],
+            x, y,
+            zone: this.zones[zoneIndex ? zoneIndex[index] : 0],
             isRiverOrFireLine: river && river[index] > 0
           };
           if (elevation) {
@@ -239,7 +257,8 @@ export class SimulationModel {
       this.cellNeighbors = calculateCellNeighbors(
         this.cells, this.gridWidth, this.gridHeight, this.config.neighborsDist
       );
-      this.notifyCellsUpdated();
+      this.updateCellsElevationFlag();
+      this.updateCellsStateFlag();
       this.dataReady = true;
     });
   }
@@ -279,7 +298,8 @@ export class SimulationModel {
     this.simulationRunning = false;
     this.simulationStarted = false;
     this.time = 0;
-    this.populateCellsData();
+    this.cells.forEach(cell => cell.reset());
+    this.updateCellsStateFlag();
   }
 
   @action.bound public reload() {
@@ -309,13 +329,15 @@ export class SimulationModel {
       this.time += 1;
     }
     this.updateFire();
-    this.notifyCellsUpdated();
+    this.updateCellsStateFlag();
   }
 
-  @action.bound public notifyCellsUpdated() {
-    // This is hopefully needed only temporarly. 2D view observers cells array directly instead of its content.
-    // It doesn't make sense to change it, as it will be eventually replaced by 3D view.
-    this.cells = this.cells.slice();
+  @action.bound public updateCellsElevationFlag() {
+    this.cellsElevationFlag += 1;
+  }
+
+  @action.bound public updateCellsStateFlag() {
+    this.cellsStateFlag += 1;
   }
 
   // Coords are in model units (feet).
@@ -335,10 +357,6 @@ export class SimulationModel {
 
   @action.bound public setWindSpeed(speed: number) {
     this.wind.speed = speed;
-  }
-
-  @action.bound public setMoistureContent(value: number) {
-    this.moistureContent = value;
   }
 
   @action.bound public updateZoneTerrain(zoneIdx: number, updatedTerrainType: TerrainType) {

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -222,7 +222,10 @@ export class SimulationModel {
   }
 
   public getRiverData(): Promise<number[] | undefined> {
-    return getInputData("data/river-texmap-data.png", this.gridWidth, this.gridHeight, true,
+    if (!this.config.riverData) {
+      return Promise.resolve(undefined);
+    }
+    return getInputData(this.config.riverData, this.gridWidth, this.gridHeight, true,
       (rgba: [number, number, number, number]) => {
         // River texture is mostly transparent, so look for non-transparent cells to define shape
         return rgba[3] > 0 ? 1 : 0;

--- a/src/models/zone.ts
+++ b/src/models/zone.ts
@@ -1,14 +1,14 @@
-import { LandType, TerrainType, DroughtLevel, moistureLookups } from "./fire-model";
+import { Vegetation, TerrainType, DroughtLevel, moistureLookups } from "./fire-model";
 import { observable } from "mobx";
 
 export interface ZoneOptions {
-  landType?: LandType;
+  vegetation?: Vegetation;
   terrainType?: TerrainType;
   droughtLevel?: number;
 }
 
 export class Zone {
-  @observable public landType: LandType = LandType.Grass;
+  @observable public vegetation: Vegetation = Vegetation.Grass;
   @observable public terrainType: TerrainType = TerrainType.Foothills;
   @observable public droughtLevel: DroughtLevel = DroughtLevel.MildDrought;
 
@@ -17,6 +17,6 @@ export class Zone {
   }
 
   public get moistureContent() {
-    return moistureLookups[this.droughtLevel][this.landType];
+    return moistureLookups[this.droughtLevel][this.vegetation];
   }
 }

--- a/src/models/zone.ts
+++ b/src/models/zone.ts
@@ -1,20 +1,22 @@
-import { LandType, TerrainType, DroughtLevel } from "./fire-model";
+import { LandType, TerrainType, DroughtLevel, moistureLookups } from "./fire-model";
 import { observable } from "mobx";
 
 export interface ZoneOptions {
   landType?: LandType;
-  moistureContent?: number; // calculated from drought & land type values
   terrainType?: TerrainType;
   droughtLevel?: number;
 }
 
 export class Zone {
   @observable public landType: LandType = LandType.Grass;
-  @observable public moistureContent: number = 0; // reasonable range seems to be [0, 0.2]
   @observable public terrainType: TerrainType = TerrainType.Foothills;
   @observable public droughtLevel: DroughtLevel = DroughtLevel.MildDrought;
 
   constructor(props: ZoneOptions) {
     Object.assign(this, props);
+  }
+
+  public get moistureContent() {
+    return moistureLookups[this.droughtLevel][this.landType];
   }
 }

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,5 +1,5 @@
 import { ISimulationConfig } from "./config";
-import { DroughtLevel, LandType, TerrainType } from "./models/fire-model";
+import { DroughtLevel, Vegetation, TerrainType } from "./models/fire-model";
 
 export interface IPresetConfig extends ISimulationConfig {
   zoneIndex: number[][] | string;
@@ -132,8 +132,8 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     gridWidth: 240,
     heightmapMaxElevation: 20000,
     zones: [
-      { terrainType: TerrainType.Foothills, landType: LandType.Grass, droughtLevel: DroughtLevel.SevereDrought },
-      { terrainType: TerrainType.Foothills, landType: LandType.Shrub, droughtLevel: DroughtLevel.MediumDrought },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.Grass, droughtLevel: DroughtLevel.SevereDrought },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.Shrub, droughtLevel: DroughtLevel.MediumDrought },
     ],
     zoneIndex: [
       [ 0, 1 ]
@@ -146,9 +146,9 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     heightmapMaxElevation: 20000,
     zonesCount: 3,
     zones: [
-      { terrainType: TerrainType.Foothills, landType: LandType.Grass, droughtLevel: 3 },
-      { terrainType: TerrainType.Foothills, landType: LandType.Shrub, droughtLevel: 2 },
-      { terrainType: TerrainType.Foothills, landType: LandType.ForestSmallLitter, droughtLevel: 0 },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.Grass, droughtLevel: 3 },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.Shrub, droughtLevel: 2 },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ForestSmallLitter, droughtLevel: 0 },
     ],
     zoneIndex: [
       [ 0, 1, 2 ]
@@ -160,9 +160,9 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     gridWidth: 240,
     heightmapMaxElevation: 20000,
     zones: [
-      { terrainType: TerrainType.Plains, landType: LandType.Grass, droughtLevel: 3 },
-      { terrainType: TerrainType.Plains, landType: LandType.Shrub, droughtLevel: 2 },
-      { terrainType: TerrainType.Plains, landType: LandType.ForestSmallLitter, droughtLevel: 0 },
+      { terrainType: TerrainType.Plains, vegetation: Vegetation.Grass, droughtLevel: 3 },
+      { terrainType: TerrainType.Plains, vegetation: Vegetation.Shrub, droughtLevel: 2 },
+      { terrainType: TerrainType.Plains, vegetation: Vegetation.ForestSmallLitter, droughtLevel: 0 },
     ],
     zonesCount: 3,
     zoneIndex: [
@@ -175,9 +175,9 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     gridWidth: 240,
     heightmapMaxElevation: 20000,
     zones: [
-      { terrainType: TerrainType.Foothills, landType: LandType.Grass, droughtLevel: 3 },
-      { terrainType: TerrainType.Foothills, landType: LandType.Shrub, droughtLevel: 2 },
-      { terrainType: TerrainType.Foothills, landType: LandType.ForestSmallLitter, droughtLevel: 0 },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.Grass, droughtLevel: 3 },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.Shrub, droughtLevel: 2 },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ForestSmallLitter, droughtLevel: 0 },
     ],
     zonesCount: 3,
     zoneIndex: [
@@ -190,9 +190,9 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     gridWidth: 240,
     heightmapMaxElevation: 20000,
     zones: [
-      { terrainType: TerrainType.Mountains, landType: LandType.Shrub, droughtLevel: 3 },
-      { terrainType: TerrainType.Mountains, landType: LandType.ForestSmallLitter, droughtLevel: 2 },
-      { terrainType: TerrainType.Mountains, landType: LandType.ForestLargeLitter, droughtLevel: 0 },
+      { terrainType: TerrainType.Mountains, vegetation: Vegetation.Shrub, droughtLevel: 3 },
+      { terrainType: TerrainType.Mountains, vegetation: Vegetation.ForestSmallLitter, droughtLevel: 2 },
+      { terrainType: TerrainType.Mountains, vegetation: Vegetation.ForestLargeLitter, droughtLevel: 0 },
     ],
     zonesCount: 3,
     zoneIndex: [
@@ -205,9 +205,9 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     gridWidth: 240,
     heightmapMaxElevation: 20000,
     zones: [
-      { terrainType: TerrainType.Mountains, landType: LandType.Grass, droughtLevel: 3 },
-      { terrainType: TerrainType.Foothills, landType: LandType.Shrub, droughtLevel: 2 },
-      { terrainType: TerrainType.Plains, landType: LandType.ForestSmallLitter, droughtLevel: 0 },
+      { terrainType: TerrainType.Mountains, vegetation: Vegetation.Grass, droughtLevel: 3 },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.Shrub, droughtLevel: 2 },
+      { terrainType: TerrainType.Plains, vegetation: Vegetation.ForestSmallLitter, droughtLevel: 0 },
     ],
     zonesCount: 3,
     zoneIndex: [

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -142,7 +142,7 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     heightmapMaxElevation: 20000,
     zonesCount: 3,
     zoneIndex: [
-      [ 0, 1, 0 ]
+      [ 0, 1, 2 ]
     ]
   },
   threeZonePlains: {

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,7 +1,10 @@
-import {ISimulationConfig} from "./config";
+import { ISimulationConfig } from "./config";
+import { DroughtLevel, LandType, TerrainType } from "./models/fire-model";
 
 export interface IPresetConfig extends ISimulationConfig {
   zoneIndex: number[][] | string;
+  // If `elevation` height map is provided, it will be loaded during model initialization and terrain setup dialog
+  // won't let users change terrain type. Otherwise, height map URL will be derived from zones `terrainType` properties.
   elevation?: number[][] | string;
 }
 
@@ -21,7 +24,7 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     gridWidth: 100,
     sparks: [ [50000, 50000] ],
     zoneIndex: [
-      [ 0, 1, 0 ]
+      [ 0, 1, 2 ]
     ]
   },
   basicWithWind: {
@@ -128,8 +131,8 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     gridWidth: 240,
     heightmapMaxElevation: 20000,
     zones: [
-      { terrainType: 1, landType: 0, droughtLevel: 3 },
-      { terrainType: 1, landType: 1, droughtLevel: 2 },
+      { terrainType: TerrainType.Foothills, landType: LandType.Grass, droughtLevel: DroughtLevel.SevereDrought },
+      { terrainType: TerrainType.Foothills, landType: LandType.Shrub, droughtLevel: DroughtLevel.MediumDrought },
     ],
     zoneIndex: [
       [ 0, 1 ]
@@ -141,6 +144,11 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     gridWidth: 240,
     heightmapMaxElevation: 20000,
     zonesCount: 3,
+    zones: [
+      { terrainType: TerrainType.Foothills, landType: LandType.Grass, droughtLevel: 3 },
+      { terrainType: TerrainType.Foothills, landType: LandType.Shrub, droughtLevel: 2 },
+      { terrainType: TerrainType.Foothills, landType: LandType.ForestSmallLitter, droughtLevel: 0 },
+    ],
     zoneIndex: [
       [ 0, 1, 2 ]
     ]
@@ -151,15 +159,14 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     gridWidth: 240,
     heightmapMaxElevation: 20000,
     zones: [
-      { terrainType: 2, landType: 0, droughtLevel: 3 },
-      { terrainType: 2, landType: 1, droughtLevel: 2 },
-      { terrainType: 2, landType: 2, droughtLevel: 0 }
+      { terrainType: TerrainType.Plains, landType: LandType.Grass, droughtLevel: 3 },
+      { terrainType: TerrainType.Plains, landType: LandType.Shrub, droughtLevel: 2 },
+      { terrainType: TerrainType.Plains, landType: LandType.ForestSmallLitter, droughtLevel: 0 },
     ],
     zonesCount: 3,
     zoneIndex: [
       [ 0, 1, 2 ]
-    ],
-    elevation: "data/plains-plains-plains-heightmap-edge.png",
+    ]
   },
   threeZoneFoothills: {
     modelWidth: 120000,
@@ -167,15 +174,14 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     gridWidth: 240,
     heightmapMaxElevation: 20000,
     zones: [
-      { terrainType: 1, landType: 0, droughtLevel: 3 },
-      { terrainType: 1, landType: 1, droughtLevel: 2 },
-      { terrainType: 1, landType: 2, droughtLevel: 0 }
+      { terrainType: TerrainType.Foothills, landType: LandType.Grass, droughtLevel: 3 },
+      { terrainType: TerrainType.Foothills, landType: LandType.Shrub, droughtLevel: 2 },
+      { terrainType: TerrainType.Foothills, landType: LandType.ForestSmallLitter, droughtLevel: 0 },
     ],
     zonesCount: 3,
     zoneIndex: [
       [ 0, 1, 2 ]
-    ],
-    elevation: "data/foothills-foothills-foothills-heightmap-edge.png",
+    ]
   },
   threeZoneMountains: {
     modelWidth: 120000,
@@ -183,15 +189,14 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     gridWidth: 240,
     heightmapMaxElevation: 20000,
     zones: [
-      { terrainType: 0, landType: 1, droughtLevel: 3 },
-      { terrainType: 0, landType: 2, droughtLevel: 2 },
-      { terrainType: 0, landType: 3, droughtLevel: 0 }
+      { terrainType: TerrainType.Mountains, landType: LandType.Shrub, droughtLevel: 3 },
+      { terrainType: TerrainType.Mountains, landType: LandType.ForestSmallLitter, droughtLevel: 2 },
+      { terrainType: TerrainType.Mountains, landType: LandType.ForestLargeLitter, droughtLevel: 0 },
     ],
     zonesCount: 3,
     zoneIndex: [
       [ 0, 1, 2 ]
-    ],
-    elevation: "data/mountains-mountains-mountains-heightmap-edge.png",
+    ]
   },
   threeZoneMix: {
     modelWidth: 120000,
@@ -199,15 +204,14 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     gridWidth: 240,
     heightmapMaxElevation: 20000,
     zones: [
-      { terrainType: 0, landType: 0, droughtLevel: 3 },
-      { terrainType: 1, landType: 1, droughtLevel: 2 },
-      { terrainType: 2, landType: 2, droughtLevel: 0 }
+      { terrainType: TerrainType.Mountains, landType: LandType.Grass, droughtLevel: 3 },
+      { terrainType: TerrainType.Foothills, landType: LandType.Shrub, droughtLevel: 2 },
+      { terrainType: TerrainType.Plains, landType: LandType.ForestSmallLitter, droughtLevel: 0 },
     ],
     zonesCount: 3,
     zoneIndex: [
       [ 0, 1, 2 ]
-    ],
-    elevation: "data/mountains-foothills-plains-heightmap-edge.png",
+    ]
   },
 };
 

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -16,7 +16,8 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     sparks: [ [50000, 50000] ],
     zoneIndex: [
       [ 0, 1 ]
-    ]
+    ],
+    riverData: null
   },
   threeZones: {
     modelWidth: 100000,


### PR DESCRIPTION
Commit names should explain what has been changed. These items are a bit independent.
The most important change I guess is how elevation data is now loaded.
There's a little confusion whether `config.elevation` data should be used or `terrainType` from zones config. I've changed logic so:
1. If there's `config.elevation` provided, zones config is ignored, user can't change terrain type, and we assume that elevation data is fixed and can't be changed. It can be useful for tests or very custom models.
2. Otherwise, elevation data is based on zones config (`terrainType`).

I renamed LandType to Vegetation, as I was constantly confusing TerrainType with LandType. :wink: