### PR TITLE
Wind effect and fire width tweaks

### DIFF
--- a/src/components/wind-circular-control.tsx
+++ b/src/components/wind-circular-control.tsx
@@ -36,25 +36,18 @@ const windScaleFactor = 0.2;
 
 export const WindCircularControl = observer(() => {
   const { simulation } = useStores();
-  const [directionAngle, setDirectionAngle] = useState(simulation.wind.direction / 360);
 
-  useEffect(() => {
-    simulation.setWindDirection(angleToDirection());
-  }, [directionAngle]);
-
-  const angleToDirection = () => {
-    // convert 0-1 scale of angle to the direction from which the wind is coming
-    // which is the inverse of this current direction
-    const fromAngle = (directionAngle * 360) + 180;
-    return fromAngle < 360 ? fromAngle : fromAngle - 360;
+  const circularInputValToAngle = (circularInputVal: number) => {
+    // Convert 0-1 scale of angle to the direction from which the wind is coming.
+    return (circularInputVal * 360 + 180) % 360;
   };
 
-  const degToCompass = () => {
-    // wind comes _from_ the opposite direction
-    const fromAngle = angleToDirection();
-    const val = Math.floor((fromAngle / 22.5) + 0.5);
-    const arr = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW",  ];
-    return arr[(val % 16)];
+  const circularInputValue = () => {
+    return (simulation.wind.direction - 180) / 360;
+  };
+
+  const setDirectionAngle = (circularInputVal: number) => {
+    simulation.setWindDirection(circularInputValToAngle(circularInputVal));
   };
 
   const handleWindSpeedChange = (event: any, value: number | number[]) => {
@@ -62,16 +55,23 @@ export const WindCircularControl = observer(() => {
   };
   const scaledWind = simulation.wind.speed / windScaleFactor;
 
+  const degToCompass = () => {
+    // wind comes _from_ the opposite direction
+    const val = Math.floor((simulation.wind.direction / 22.5) + 0.5);
+    const arr = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"];
+    return arr[(val % 16)];
+  };
+
   return (
     <div className={css.windContainer}>
       <div className={css.controlContainer}>
-        <div className={css.windSymbolContainer} style={{transform: `rotate(${360 * directionAngle}deg)`}}>
+        <div className={css.windSymbolContainer} style={{transform: `rotate(${simulation.wind.direction + 180}deg)`}}>
           <WindSymbol className={css.windSymbol} />
         </div>
         <div className={css.dialContainer}>
           <WindDial className={css.dial} />
-          <WindArrow className={css.arrow} style={{transform: `rotate(${360 * directionAngle}deg)`}}/>
-          <CircularInput value={directionAngle} radius={35}
+          <WindArrow className={css.arrow} style={{transform: `rotate(${simulation.wind.direction + 180}deg)`}}/>
+          <CircularInput value={circularInputValue()} radius={35}
             onChange={setDirectionAngle} className={css.windCircularControl}>
             <CircularTrack strokeWidth={4} stroke="rgba(255,255,255,0.5)" fill="rgba(255,255,255,0)" />
           </CircularInput>

--- a/src/components/wind-circular-control.tsx
+++ b/src/components/wind-circular-control.tsx
@@ -10,6 +10,7 @@ import WindSymbol from "../assets/wind-symbol.svg";
 import css from "./wind-circular-control.scss";
 import { Slider } from "@material-ui/core";
 import HorizontalHandle from "../assets/slider-horizontal.svg";
+import { observer } from "mobx-react";
 
 const windSpeedMarks = [
   {
@@ -29,15 +30,17 @@ const windSpeedMarks = [
     label: "30"
   }
 ];
-export const WindCircularControl = () => {
-  const { simulation, ui } = useStores();
+
+// Note that model is very sensitive to wind. Scale wind values down for now, so changes are less dramatic.
+const windScaleFactor = 0.2;
+
+export const WindCircularControl = observer(() => {
+  const { simulation } = useStores();
   const [directionAngle, setDirectionAngle] = useState(simulation.wind.direction / 360);
-  const [windSpeed, setWindSpeed] = useState(simulation.wind.speed);
 
   useEffect(() => {
     simulation.setWindDirection(angleToDirection());
-    simulation.setWindSpeed(windSpeed);
-  }, [directionAngle, windSpeed]);
+  }, [directionAngle]);
 
   const angleToDirection = () => {
     // convert 0-1 scale of angle to the direction from which the wind is coming
@@ -55,8 +58,9 @@ export const WindCircularControl = () => {
   };
 
   const handleWindSpeedChange = (event: any, value: number | number[]) => {
-    setWindSpeed(value as number);
+    simulation.setWindSpeed(value as number * windScaleFactor);
   };
+  const scaledWind = simulation.wind.speed / windScaleFactor;
 
   return (
     <div className={css.windContainer}>
@@ -75,14 +79,14 @@ export const WindCircularControl = () => {
       </div>
 
       <div className={css.key}>Wind Direction and Speed</div>
-      <div className={css.windText}>{`${windSpeed} MPH from the ${degToCompass()}`}
+      <div className={css.windText}>{`${Math.round(scaledWind)} MPH from the ${degToCompass()}`}
         <div className={css.windSliderControls}>
           <Slider
             classes={{ thumb: css.thumb, markLabel: css.markLabel }}
             min={0}
             max={30}
             disabled={simulation.simulationStarted}
-            value={windSpeed}
+            value={scaledWind}
             step={1}
             marks={windSpeedMarks}
             onChange={handleWindSpeedChange}
@@ -92,4 +96,4 @@ export const WindCircularControl = () => {
       </div>
     </div>
   );
-};
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ export interface ISimulationConfig {
   // In min - note that larger cells will burn the same amount of time. Cell doesn't burn from edge to edge, but
   // its whole area is supposed to burn at the same time. We might consider whether it should be different for
   // different fuel types.
-  cellBurnTime: number;
+  minCellBurnTime: number;
   // Max elevation of 100% white points in heightmap (image used for elevation data).
   heightmapMaxElevation: number; // ft
   // Number of zones that the model is using. Zones are used to keep properties of some area of the model.
@@ -48,7 +48,7 @@ export const defaultConfig: IUrlConfig = {
   // 2.5 seems to be first value that ensures that fire front looks pretty round.
   // Higher values will make this shape better, but performance will be affected.
   neighborsDist: 2.5,
-  cellBurnTime: 2000, // minutes
+  minCellBurnTime: 200, // minutes
   heightmapMaxElevation: 20000,
   zonesCount: 2,
   zones: [

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -22,6 +22,7 @@ export class Cell {
   public zone: Zone;
   public elevation: number = 0;
   public ignitionTime: number = Infinity;
+  public burnTime: number = Infinity;
   public fireState: FireState = FireState.Unburnt;
   public isRiverOrFireLine: boolean = false;
 
@@ -47,6 +48,7 @@ export class Cell {
 
   public reset() {
     this.ignitionTime = Infinity;
+    this.burnTime = Infinity;
     this.fireState = FireState.Unburnt;
   }
 }

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -396,7 +396,7 @@ export class SimulationModel {
 
     for (let i = 0; i < numCells; i++) {
       const ignitionTime = this.cells[i].ignitionTime;
-      if (this.cells[i].fireState === FireState.Burning && this.time - ignitionTime > this.config.cellBurnTime) {
+      if (this.cells[i].fireState === FireState.Burning && this.time - ignitionTime > this.cells[i].burnTime) {
         newFireStateData[i] = FireState.Burnt;
       } else if (this.cells[i].fireState === FireState.Unburnt && this.time > ignitionTime) {
         // Sets any unburnt cells to burning if we are passed their ignition time.
@@ -412,6 +412,11 @@ export class SimulationModel {
             newIgnitionData[n] = Math.min(
               ignitionTime + ignitionDeltas[j], newIgnitionData[n] || this.cells[n].ignitionTime
             );
+            // Make cell burn time proportional to fire spread rate.
+            const newBurnTime = (newIgnitionData[n] - ignitionTime) + this.config.minCellBurnTime;
+            if (newBurnTime < this.cells[n].burnTime) {
+              this.cells[n].burnTime = newBurnTime;
+            }
           }
         });
       }

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -214,6 +214,29 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
       [ 0, 1, 2 ]
     ]
   },
+  extremeZones: {
+    modelWidth: 120000,
+    modelHeight: 80000,
+    gridWidth: 240,
+    heightmapMaxElevation: 20000,
+    zones: [
+      {
+        terrainType: TerrainType.Mountains,
+        vegetation: Vegetation.ForestLargeLitter,
+        droughtLevel: DroughtLevel.SevereDrought
+      },
+      {
+        terrainType: TerrainType.Foothills,
+        vegetation: Vegetation.Shrub,
+        droughtLevel: DroughtLevel.MediumDrought
+      },
+      { terrainType: TerrainType.Plains, vegetation: Vegetation.Grass, droughtLevel: DroughtLevel.NoDrought }
+    ],
+    zonesCount: 3,
+    zoneIndex: [
+      [ 0, 1, 2 ]
+    ]
+  },
 };
 
 export default presets;


### PR DESCRIPTION
This PR addresses two different stories:
https://www.pivotaltracker.com/story/show/170087787
https://www.pivotaltracker.com/story/show/170087691

Wind effect was too dramatic before, so I just scaled down values for now.
Fire width tweaks turned out to be much more challenging, but I think the current approach produces better results. Width is still different in different cases, but in some sense, it reflects the intensity of the fire. Slowly burning grass looks more like it's smoldering, while the fire in the mountains is pretty wide and intense. I've added a new preset that shows the difference clearly:
http://wildfire.concord.org/branch/wind/index.html?preset=extremeZones


