### PR TITLE
Add town names and `showCoordsOnClick` mode

### DIFF
--- a/src/components/view-3d/fire-line-marker.tsx
+++ b/src/components/view-3d/fire-line-marker.tsx
@@ -15,7 +15,7 @@ export const FireLineMarkersContainer = observer(({ getTerrain }) => {
           key={idx}
           markerImg={fireLineImg}
           markerHighlightImg={fireLineHighlightImg}
-          position={simulation.fireLineMarkers[idx]}
+          position={fl}
           setPosition={setPosition}
           getTerrain={getTerrain}
         />;

--- a/src/components/view-3d/marker.tsx
+++ b/src/components/view-3d/marker.tsx
@@ -9,39 +9,52 @@ import { useInteractions } from "./use-interactions";
 import { SpriteMaterial } from "three";
 
 interface IProps {
-  markerImg: string;
-  markerHighlightImg: string;
+  // Image src or HTML Canvas that is going to be used as a texture source.
+  markerImg: string | HTMLCanvasElement;
   position: {x: number, y: number};
-  setPosition: (x: number, y: number) => void;
-  getTerrain: () => THREE.Mesh;
+  // Width relative to the plane/terrain width.
+  width?: number;
+  // Height relative to the plane/terrain width.
+  height?: number;
+  anchorX?: number;
+  anchorY?: number;
+  // setPosition enabled dragging
+  setPosition?: (x: number, y: number) => void;
+  // getTerrain provides a based mesh used for dragging. Necessary for dragging to work.
+  getTerrain?: () => THREE.Mesh;
+  // Optional highlight image that we'll be activated on hover.
+  markerHighlightImg?: string | HTMLCanvasElement;
   lockOnSimStart?: boolean;
 }
 
-const SIZE = 0.06 * PLANE_WIDTH;
+// const SIZE = 0.06 * PLANE_WIDTH;
 
 const setupMesh = ({ scene }: IThreeContext) => {
   const sprite = new THREE.Sprite();
-  // Move anchor point to bottom.
-  sprite.center.y = 0;
-  sprite.scale.set(SIZE, SIZE, 1);
   // Ensure that sprite is always rendered on top of other geometry, so e.g. it doesn't disappear under a mountain.
   sprite.renderOrder = 1;
   scene.add(sprite);
   return sprite;
 };
 
-const getMaterial = (imgSrc: string) => {
-  const image = document.createElement("img");
-  image.src = imgSrc;
-  image.onload = () =>  { texture.needsUpdate = true; };
-  const texture = new THREE.Texture(image);
+const getMaterial = (imgSrcOrCanvas: string | HTMLCanvasElement) => {
+  let source;
+  if (typeof imgSrcOrCanvas === "string") {
+    source = document.createElement("img");
+    source.src = imgSrcOrCanvas;
+  } else {
+    source = imgSrcOrCanvas; // canvas
+  }
+  const texture = new THREE.Texture(source);
+  texture.needsUpdate = true;
   const material = new THREE.SpriteMaterial({ map: texture });
   material.depthTest = false;
   return material;
 };
 
 export const Marker: React.FC<IProps> = observer(({
-  markerImg, markerHighlightImg, position, setPosition, getTerrain, lockOnSimStart = false
+  markerImg, markerHighlightImg, position, setPosition, getTerrain,
+  width = 0.06, height = 0.06, anchorX = 0.5, anchorY = 0, lockOnSimStart = false
 }) => {
   const defMaterial = useRef<SpriteMaterial>();
   const highlightMaterial = useRef<SpriteMaterial>();
@@ -49,20 +62,31 @@ export const Marker: React.FC<IProps> = observer(({
 
   const { getEntity } = useThree<THREE.Sprite>(setupMesh);
 
+  const marker = getEntity();
+  if (marker) {
+    marker.center.x = anchorX;
+    marker.center.y = anchorY;
+    marker.scale.set(width * PLANE_WIDTH, height * PLANE_WIDTH, 1);
+  }
+
   useEffect(() => {
     defMaterial.current = getMaterial(markerImg);
-    highlightMaterial.current = getMaterial(markerHighlightImg);
-    const marker = getEntity();
-    if (marker) {
-      marker.material = defMaterial.current;
+    if (markerHighlightImg) {
+      highlightMaterial.current = getMaterial(markerHighlightImg);
+    }
+    const sprite = getEntity();
+    if (sprite) {
+      sprite.material = defMaterial.current;
     }
     return () => {
       defMaterial!.current!.map!.dispose();
       defMaterial!.current!.dispose();
-      highlightMaterial!.current!.map!.dispose();
-      highlightMaterial!.current!.dispose();
+      if (markerHighlightImg) {
+        highlightMaterial!.current!.map!.dispose();
+        highlightMaterial!.current!.dispose();
+      }
     };
-  }, []);
+  }, [markerImg, markerHighlightImg]);
 
   useEffect(() => {
     const sprite = getEntity();
@@ -73,34 +97,36 @@ export const Marker: React.FC<IProps> = observer(({
     }
   }, [position, simulation.dataReady]);
 
-  const dragging = useInteractions({
-    getObject: getEntity,
-    getDragBaseObject: getTerrain,
-    onDrag: (x: number, y: number) => {
-      const ratio = ftToViewUnit(simulation);
-      setPosition(x / ratio, y / ratio);
-    },
-    onMouseOver: () => {
-      const marker = getEntity();
-      if (marker) {
-        marker.material = highlightMaterial.current!;
+  if (setPosition && getTerrain) {
+    const dragging = useInteractions({
+      getObject: getEntity,
+      getDragBaseObject: getTerrain,
+      onDrag: (x: number, y: number) => {
+        const ratio = ftToViewUnit(simulation);
+        setPosition(x / ratio, y / ratio);
+      },
+      onMouseOver: () => {
+        const sprite = getEntity();
+        if (sprite && highlightMaterial.current) {
+          sprite.material = highlightMaterial.current;
+        }
+        return "grab"; // cursor
+      },
+      onMouseOut: () => {
+        const sprite = getEntity();
+        if (sprite) {
+          sprite.material = defMaterial.current!;
+        }
       }
-      return "grab"; // cursor
-    },
-    onMouseOut: () => {
-      const marker = getEntity();
-      if (marker) {
-        marker.material = defMaterial.current!;
-      }
-    }
-  });
+    });
 
-  useEffect(() => {
-    if (ui.interaction === null && (!lockOnSimStart || !simulation.simulationStarted)) {
-      dragging.enable();
-    }
-    return dragging.disable;
-  }, [ui.interaction, simulation.simulationStarted]);
+    useEffect(() => {
+      if (ui.interaction === null && (!lockOnSimStart || !simulation.simulationStarted)) {
+        dragging.enable();
+      }
+      return dragging.disable;
+    }, [ui.interaction, simulation.simulationStarted]);
+  }
 
   if (lockOnSimStart) {
     useEffect(() => {
@@ -109,9 +135,9 @@ export const Marker: React.FC<IProps> = observer(({
         return;
       }
       if (simulation.simulationStarted) {
-        sprite.scale.set(SIZE * 0.5, SIZE * 0.5, 1);
+        sprite.scale.set(width * PLANE_WIDTH * 0.5, height * PLANE_WIDTH * 0.5, 1);
       } else {
-        sprite.scale.set(SIZE, SIZE, 1);
+        sprite.scale.set(width * PLANE_WIDTH, height * PLANE_WIDTH, 1);
       }
     }, [simulation.simulationStarted]);
   }

--- a/src/components/view-3d/show-coords-interaction.tsx
+++ b/src/components/view-3d/show-coords-interaction.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from "react";
+import * as THREE from "three";
+import { observer } from "mobx-react";
+import { useStores } from "../../use-stores";
+import { ftToViewUnit } from "./helpers";
+import { useInteractions } from "./use-interactions";
+
+interface IProps {
+  getTerrain: () => THREE.Mesh | undefined;
+}
+
+export const ShowCoordsInteraction: React.FC<IProps> = observer(({ getTerrain }) => {
+  const { simulation } = useStores();
+  const showCoords = useInteractions({
+    getObject: getTerrain,
+    onClick: (x, y) => {
+      const ratio = ftToViewUnit(simulation);
+      const xFt = x / ratio;
+      const yFt = y / ratio;
+      const xRel = xFt / simulation.config.modelWidth;
+      const yRel = yFt / simulation.config.modelHeight;
+      window.alert(
+        `x: ${xFt.toFixed(3)} ft, y: ${yFt.toFixed(3)} ft\n` +
+        `x relative: ${xRel.toFixed(3)}, y relative: ${yRel.toFixed(3)}`
+      );
+    }
+  });
+
+  useEffect(() => {
+    showCoords.enable();
+    return showCoords.disable;
+  }, []);
+
+  return null;
+});

--- a/src/components/view-3d/spark.tsx
+++ b/src/components/view-3d/spark.tsx
@@ -15,7 +15,7 @@ export const SparksContainer = observer(({ getTerrain }) => {
           key={idx}
           markerImg={sparkImg}
           markerHighlightImg={sparkHighlightImg}
-          position={simulation.sparks[idx]}
+          position={s}
           setPosition={setPosition}
           getTerrain={getTerrain}
           lockOnSimStart={true}

--- a/src/components/view-3d/terrain.tsx
+++ b/src/components/view-3d/terrain.tsx
@@ -14,6 +14,7 @@ import { AddSparkInteraction } from "./add-spark-interaction";
 import { DrawFireLineInteraction } from "./draw-fire-line-interaction";
 import { DroughtLevel } from "../../models/fire-model";
 import { FireLineMarkersContainer } from "./fire-line-marker";
+import { TownMarkersContainer } from "./town-marker";
 import { ISimulationConfig } from "../../config";
 
 const getTerrainColor = (droughtLevel: number) => {
@@ -134,6 +135,7 @@ export const Terrain = observer(() => {
   return <>
     <SparksContainer getTerrain={getEntity}/>
     <FireLineMarkersContainer getTerrain={getEntity}/>
+    <TownMarkersContainer/>
     { ui.interaction === Interaction.PlaceSpark && <AddSparkInteraction getTerrain={getEntity} /> }
     { ui.interaction === Interaction.DrawFireLine && <DrawFireLineInteraction getTerrain={getEntity} /> }
   </>;

--- a/src/components/view-3d/terrain.tsx
+++ b/src/components/view-3d/terrain.tsx
@@ -16,6 +16,7 @@ import { DroughtLevel } from "../../models/fire-model";
 import { FireLineMarkersContainer } from "./fire-line-marker";
 import { TownMarkersContainer } from "./town-marker";
 import { ISimulationConfig } from "../../config";
+import { ShowCoordsInteraction } from "./show-coords-interaction";
 
 const getTerrainColor = (droughtLevel: number) => {
   switch (droughtLevel) {
@@ -138,5 +139,6 @@ export const Terrain = observer(() => {
     <TownMarkersContainer/>
     { ui.interaction === Interaction.PlaceSpark && <AddSparkInteraction getTerrain={getEntity} /> }
     { ui.interaction === Interaction.DrawFireLine && <DrawFireLineInteraction getTerrain={getEntity} /> }
+    { simulation.config.showCoordsOnClick && <ShowCoordsInteraction getTerrain={getEntity} /> }
   </>;
 });

--- a/src/components/view-3d/town-marker.tsx
+++ b/src/components/view-3d/town-marker.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { observer } from "mobx-react";
+import { useStores } from "../../use-stores";
+import { Marker } from "./marker";
+
+const font = (size: number) => {
+  return `${size}px Lato, arial, helvetica, sans-serif`;
+};
+
+const labelCanvas = (label: string) => {
+  const width = 512;
+  const height = 128;
+  const dotRadius = height / 8;
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return canvas;
+  }
+  // Dot
+  const lineWidth = width / 64;
+  ctx.lineWidth = lineWidth;
+  ctx.beginPath();
+  ctx.arc(dotRadius + lineWidth * 0.5, height - dotRadius - lineWidth * 0.5, dotRadius, 0, 2 * Math.PI);
+  ctx.strokeStyle = "#797979";
+  ctx.fillStyle = "#fff";
+  ctx.stroke();
+  ctx.fill();
+  // Label
+  ctx.font = font(height * 0.4);
+  ctx.fillText(label, dotRadius * 2.5, height - dotRadius * 2.5, width);
+  return canvas;
+};
+
+export const TownMarkersContainer = observer(({ getTerrain }) => {
+  const { simulation } = useStores();
+  return <>
+    {
+      simulation.townMarkers.map((town, idx) => {
+        return <Marker
+          key={idx}
+          markerImg={labelCanvas(town.name)}
+          position={town.position}
+          width={0.2}
+          height={0.05}
+          anchorX={0.03} // move anchor point to the left, trying to match the dot
+        />;
+      })
+    }
+  </>;
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ interface TownOptions {
   name: string;
   x: number; // [0, 1], position relative to model width
   y: number; // [0, 1], position relative to model height
-  terrainType: TerrainType | undefined; // limit town marker to given terrain type
+  terrainType?: TerrainType; // limit town marker to given terrain type
 }
 
 export interface ISimulationConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,8 @@ export interface ISimulationConfig {
   maxFireLineLength: number; // ft
   // Renders burn index.
   showBurnIndex: boolean;
+  // Displays alert with current coordinates on mouse click. Useful for authoring.
+  showCoordsOnClick: boolean;
 }
 
 export interface IUrlConfig extends ISimulationConfig {
@@ -91,7 +93,8 @@ export const defaultConfig: IUrlConfig = {
   showModelDimensions: false,
   fireLineDelay: 1440, // a day
   maxFireLineLength: 15000, // ft
-  showBurnIndex: false
+  showBurnIndex: false,
+  showCoordsOnClick: false
 };
 
 export const urlConfig: any = {};

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,13 @@
 import { ZoneOptions } from "./models/zone";
 import { DroughtLevel, Vegetation, TerrainType } from "./models/fire-model";
 
+interface TownOptions {
+  name: string;
+  x: number; // [0, 1], position relative to model width
+  y: number; // [0, 1], position relative to model height
+  terrainType: TerrainType | undefined; // limit town marker to given terrain type
+}
+
 export interface ISimulationConfig {
   modelWidth: number; // ft
   modelHeight: number; // ft
@@ -24,6 +31,7 @@ export interface ISimulationConfig {
   // Number of zones that the model is using. Zones are used to keep properties of some area of the model.
   zonesCount: 2 | 3;
   zones: [ZoneOptions, ZoneOptions, ZoneOptions?];
+  towns: TownOptions[];
   fillTerrainEdges: boolean;
   riverData: string | null;
   windScaleFactor: number;
@@ -75,6 +83,7 @@ export const defaultConfig: IUrlConfig = {
       droughtLevel: DroughtLevel.SevereDrought
     }
   ],
+  towns: [],
   fillTerrainEdges: true,
   riverData: "data/river-texmap-data.png",
   windScaleFactor: 0.2, // Note that model is very sensitive to wind.

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -6,6 +6,7 @@ import { IPresetConfig } from "../presets";
 import { getInputData } from "../utils";
 import { Vector2 } from "three";
 import { Zone } from "./zone";
+import { Town } from "../types";
 
 interface ICoords {
   x: number;
@@ -171,6 +172,7 @@ export class SimulationModel {
   @observable public wind: IWindProps;
   @observable public sparks: Vector2[] = [];
   @observable public fireLineMarkers: Vector2[] = [];
+  @observable public townMarkers: Town[] = [];
   @observable public cellSize: number;
   @observable public gridWidth: number;
   @observable public gridHeight: number;
@@ -297,6 +299,7 @@ export class SimulationModel {
       }
       this.updateCellsElevationFlag();
       this.updateCellsStateFlag();
+      this.updateTownMarkers();
       this.dataReady = true;
       this.recalculateCellProps = true;
     });
@@ -425,6 +428,18 @@ export class SimulationModel {
 
   @action.bound public updateCellsStateFlag() {
     this.cellsStateFlag += 1;
+  }
+
+  @action.bound public updateTownMarkers() {
+    this.townMarkers.length = 0;
+    this.config.towns.forEach(town => {
+      const x = town.x * this.config.modelWidth;
+      const y = town.y * this.config.modelHeight;
+      const cell = this.cellAt(x, y);
+      if (town.terrainType === undefined || town.terrainType === cell.zone.terrainType) {
+        this.townMarkers.push({ name: town.name, position: new Vector2(x, y) });
+      }
+    });
   }
 
   @action.bound public addSpark(x: number, y: number) {

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,5 +1,5 @@
 import { ISimulationConfig } from "./config";
-import { DroughtLevel, Vegetation, TerrainType } from "./models/fire-model";
+import { DroughtLevel, TerrainType, Vegetation } from "./models/fire-model";
 
 export interface IPresetConfig extends ISimulationConfig {
   zoneIndex: number[][] | string;
@@ -134,6 +134,17 @@ const presets: {[key: string]: Partial<IPresetConfig>} = {
     zones: [
       { terrainType: TerrainType.Foothills, vegetation: Vegetation.Grass, droughtLevel: DroughtLevel.SevereDrought },
       { terrainType: TerrainType.Foothills, vegetation: Vegetation.Shrub, droughtLevel: DroughtLevel.MediumDrought },
+    ],
+    towns: [
+      { name: "Skyview", x: 0.12, y: 0.68, terrainType: TerrainType.Mountains },
+      { name: "Peaksburg", x: 0.77, y: 0.37, terrainType: TerrainType.Mountains },
+      { name: "Happy Valley", x: 0.31, y: 0.36, terrainType: TerrainType.Mountains },
+      { name: "Sunrise", x: 0.81, y: 0.60, terrainType: TerrainType.Foothills },
+      { name: "Hillsboro", x: 0.36, y: 0.55, terrainType: TerrainType.Foothills },
+      { name: "Rolling Rock", x: 0.60, y: 0.25, terrainType: TerrainType.Foothills },
+      { name: "Evensville", x: 0.78, y: 0.55, terrainType: TerrainType.Plains },
+      { name: "Meadowland", x: 0.15, y: 0.55, terrainType: TerrainType.Plains },
+      { name: "Greenfield", x: 0.40, y: 0.15, terrainType: TerrainType.Plains }
     ],
     zoneIndex: [
       [ 0, 1 ]

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,14 @@
+import { Vector2 } from "three";
+
 export interface Fuel {
   sav: number;
   packingRatio: number;
   netFuelLoad: number;
   mx: number;
   fuelBedDepth: number;
+}
+
+export interface Town {
+  name: string;
+  position: Vector2;
 }


### PR DESCRIPTION
Town names are specified in the config / preset as a list. Each town has name, relative position (so it's independent of model dimensions changes if we ever want to tweak it), and it can be limited to just one terrain type. That way we can specify just one list, but only subset of towns will be displayed, depending on user choices (terrain type selected in the terrain setup dialog).

I've also added `showCoordsOnClick` so it's easy to tweak town position and add new ones. Otherwise, we'd have to guess coordinates.

Trudi seemed to be quite happy about this approach (so far). 