### PR TITLE
Fix a bug related to fire lines, improve time step calculations

### DIFF
--- a/src/models/simulation.test.ts
+++ b/src/models/simulation.test.ts
@@ -107,4 +107,24 @@ describe("SimulationModel", () => {
     sim.cells.forEach(c => expect(c.isUnburntIsland).toEqual(false));
     expect(sim.cells.filter(c => c.isBurningOrWillBurn).length).toBeGreaterThan(0);
   });
+
+  it("should let user add fire line after model reset", async () => {
+    const sim = new SimulationModel({
+      modelWidth: 100000,
+      modelHeight: 100000,
+      gridWidth: 5,
+      sparks: [ [50000, 50000] ],
+      zoneIndex: [[0]],
+      elevation: [[0]],
+      unburntIslands: [[1]],
+      unburntIslandProbability: 1,
+      riverData: null,
+    });
+    await sim.dataReadyPromise;
+    expect(sim.canAddFireLineMarker()).toEqual(true);
+    expect(sim.buildFireLine({x: 0, y: 50000}, {x: 50000, y: 50000}));
+    expect(sim.canAddFireLineMarker()).toEqual(false);
+    sim.restart();
+    expect(sim.canAddFireLineMarker()).toEqual(true);
+  });
 });


### PR DESCRIPTION
[#171821528]

Changes to time step calculations should fix large jump / model progression that we can currently see right after adding a fire line and starting model again.