### PR TITLE
Don't pre-calculate model

### DIFF
--- a/src/models/cell.test.ts
+++ b/src/models/cell.test.ts
@@ -1,0 +1,60 @@
+import { BurnIndex, Cell } from "./cell";
+import { Zone } from "./zone";
+
+describe("Cell model", () => {
+  describe("isNonburnable", () => {
+    it("returns false for rivers and unburnt islands", () => {
+      const zone = {} as Zone;
+      const x = 0;
+      const y = 0;
+      let cell = new Cell({x, y, zone});
+      expect(cell.isNonburnable).toEqual(false);
+      expect(cell.isNonburnable).toEqual(false);
+      expect(cell.isNonburnable).toEqual(false);
+
+      cell = new Cell({x, y, zone, isRiver: true});
+      expect(cell.isNonburnable).toEqual(true);
+      expect(cell.isNonburnable).toEqual(true);
+      expect(cell.isNonburnable).toEqual(true);
+
+      cell = new Cell({x, y, zone, isUnburntIsland: true});
+      expect(cell.isNonburnable).toEqual(true);
+      expect(cell.isNonburnable).toEqual(true);
+      expect(cell.isNonburnable).toEqual(true);
+
+      // Fire lines can still burn when fire is intense enough.
+      cell = new Cell({x, y, zone, isFireLine: true});
+      expect(cell.isNonburnable).toEqual(false);
+      expect(cell.isNonburnable).toEqual(false);
+      expect(cell.isNonburnable).toEqual(false);
+    });
+  });
+
+  describe("isBurnableForBI", () => {
+    it("returns false for nonburnable cells (rivers, unburnt islands) and result based on BI for fire lines", () => {
+      const zone = {} as Zone;
+      const x = 0;
+      const y = 0;
+      let cell = new Cell({x, y, zone});
+      expect(cell.isBurnableForBI(BurnIndex.Low)).toEqual(true);
+      expect(cell.isBurnableForBI(BurnIndex.Medium)).toEqual(true);
+      expect(cell.isBurnableForBI(BurnIndex.High)).toEqual(true);
+
+      cell = new Cell({x, y, zone, isRiver: true});
+      expect(cell.isBurnableForBI(BurnIndex.Low)).toEqual(false);
+      expect(cell.isBurnableForBI(BurnIndex.Medium)).toEqual(false);
+      expect(cell.isBurnableForBI(BurnIndex.High)).toEqual(false);
+
+      cell = new Cell({x, y, zone, isUnburntIsland: true});
+      expect(cell.isBurnableForBI(BurnIndex.Low)).toEqual(false);
+      expect(cell.isBurnableForBI(BurnIndex.Medium)).toEqual(false);
+      expect(cell.isBurnableForBI(BurnIndex.High)).toEqual(false);
+
+      cell = new Cell({x, y, zone, isFireLine: true});
+      expect(cell.isBurnableForBI(BurnIndex.Low)).toEqual(false);
+      expect(cell.isBurnableForBI(BurnIndex.Medium)).toEqual(false);
+      expect(cell.isBurnableForBI(BurnIndex.High)).toEqual(true); // !!!
+    });
+  });
+});
+

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -59,15 +59,15 @@ export class Cell {
     return this.baseElevation;
   }
 
-  public get moistureContent() {
-    if (this.isBurnable) {
-      return this.zone.moistureContent;
-    }
-    return Infinity;
+  public get isNonburnable() {
+    return this.isRiver || this.isUnburntIsland;
   }
 
-  public get isBurnable() {
-    return !this.isRiver && !this.isUnburntIsland && !this.isFireLine;
+  public get moistureContent() {
+    if (this.isNonburnable) {
+      return Infinity;
+    }
+    return this.zone.moistureContent;
   }
 
   public get droughtLevel() {
@@ -109,6 +109,11 @@ export class Cell {
       return BurnIndex.Medium;
     }
     return BurnIndex.High;
+  }
+
+  public isBurnableForBI(burnIndex: BurnIndex) {
+    // Fire lines will burn when burn index is high.
+    return !this.isNonburnable && (!this.isFireLine || burnIndex === BurnIndex.High);
   }
 
   public reset() {

--- a/src/models/fire-model.ts
+++ b/src/models/fire-model.ts
@@ -224,5 +224,5 @@ export const getFireSpreadRate = (
           (c * Math.pow(packingRatio / optimumPackingRatio, -e)), 1 / b);
 
   const directionFactor = getDirectionFactor(sourceCell, targetCell, effectiveWindSpeed, maxSpreadRateVector.angle());
-  return rh * directionFactor / distInFt;
+  return rh * directionFactor;
 };

--- a/src/models/simulation.test.ts
+++ b/src/models/simulation.test.ts
@@ -1,26 +1,28 @@
-import { getGridCellNeighbors, nonburnableCellBetween, withinDist, SimulationModel } from "./simulation";
-import { Cell } from "./cell";
+import { getGridCellNeighbors, nonburnableCellBetween, SimulationModel, withinDist } from "./simulation";
+import { BurnIndex, Cell } from "./cell";
 
 describe("nonburnableCellBetween", () => {
   it("returns true if there's any nonburnable cell between two points", () => {
+    const burnable = (bi: BurnIndex) => true;
+    const nonburnable = (bi: BurnIndex) => false;
     const cells = [
-      {isBurnable: true}, {isBurnable: true}, {isBurnable: true}, {isBurnable: true},
-      {isBurnable: true}, {isBurnable: true}, {isBurnable: true}, {isBurnable: true},
-      {isBurnable: true}, {isBurnable: false}, {isBurnable: false}, {isBurnable: false},
-      {isBurnable: true}, {isBurnable: true}, {isBurnable: true}, {isBurnable: true},
+      {isBurnableForBI: burnable}, {isBurnableForBI: burnable}, {isBurnableForBI: burnable}, {isBurnableForBI: burnable},
+      {isBurnableForBI: burnable}, {isBurnableForBI: burnable}, {isBurnableForBI: burnable}, {isBurnableForBI: burnable},
+      {isBurnableForBI: burnable}, {isBurnableForBI: nonburnable}, {isBurnableForBI: nonburnable}, {isBurnableForBI: nonburnable},
+      {isBurnableForBI: burnable}, {isBurnableForBI: burnable}, {isBurnableForBI: burnable}, {isBurnableForBI: burnable},
     ] as Cell[];
-    expect(nonburnableCellBetween(cells, 4, 0, 0, 0, 3)).toEqual(false);
-    expect(nonburnableCellBetween(cells, 4, 0, 0, 0, 3)).toEqual(false);
+    expect(nonburnableCellBetween(cells, 4, 0, 0, 0, 3, BurnIndex.Low)).toEqual(false);
+    expect(nonburnableCellBetween(cells, 4, 0, 0, 0, 3, BurnIndex.Low)).toEqual(false);
 
-    expect(nonburnableCellBetween(cells, 4, 1, 0, 0, 3)).toEqual(false);
-    expect(nonburnableCellBetween(cells, 4, 1, 1, 0, 2)).toEqual(false);
-    expect(nonburnableCellBetween(cells, 4, 1, 1, 0, 3)).toEqual(true);
+    expect(nonburnableCellBetween(cells, 4, 1, 0, 0, 3, BurnIndex.Low)).toEqual(false);
+    expect(nonburnableCellBetween(cells, 4, 1, 1, 0, 2, BurnIndex.Low)).toEqual(false);
+    expect(nonburnableCellBetween(cells, 4, 1, 1, 0, 3, BurnIndex.Low)).toEqual(true);
 
-    expect(nonburnableCellBetween(cells, 4, 1, 0, 1, 2)).toEqual(true);
-    expect(nonburnableCellBetween(cells, 4, 1, 0, 1, 3)).toEqual(true);
+    expect(nonburnableCellBetween(cells, 4, 1, 0, 1, 2, BurnIndex.Low)).toEqual(true);
+    expect(nonburnableCellBetween(cells, 4, 1, 0, 1, 3, BurnIndex.Low)).toEqual(true);
 
-    expect(nonburnableCellBetween(cells, 4, 1, 0, 2, 2)).toEqual(true);
-    expect(nonburnableCellBetween(cells, 4, 1, 0, 2, 3)).toEqual(true);
+    expect(nonburnableCellBetween(cells, 4, 1, 0, 2, 2, BurnIndex.Low)).toEqual(true);
+    expect(nonburnableCellBetween(cells, 4, 1, 0, 2, 3, BurnIndex.Low)).toEqual(true);
   });
 });
 
@@ -35,17 +37,19 @@ describe("withinDist", () => {
 
 describe("getGridCellNeighbors", () => {
   it("returns array of neighbours without cells that are nonburnable, or lay behind them", () => {
+    const burnable = (bi: BurnIndex) => true;
+    const nonburnable = (bi: BurnIndex) => false;
     const cells = [
-      {isBurnable: true}, {isBurnable: true}, {isBurnable: true}, {isBurnable: true},
-      {isBurnable: true}, {isBurnable: true}, {isBurnable: true}, {isBurnable: true},
-      {isBurnable: true}, {isBurnable: false}, {isBurnable: false}, {isBurnable: false},
-      {isBurnable: true}, {isBurnable: true}, {isBurnable: true}, {isBurnable: true},
+      {isBurnableForBI: burnable}, {isBurnableForBI: burnable}, {isBurnableForBI: burnable}, {isBurnableForBI: burnable},
+      {isBurnableForBI: burnable}, {isBurnableForBI: burnable}, {isBurnableForBI: burnable}, {isBurnableForBI: burnable},
+      {isBurnableForBI: burnable}, {isBurnableForBI: nonburnable}, {isBurnableForBI: nonburnable}, {isBurnableForBI: nonburnable},
+      {isBurnableForBI: burnable}, {isBurnableForBI: burnable}, {isBurnableForBI: burnable}, {isBurnableForBI: burnable},
     ] as Cell[];
-    expect(getGridCellNeighbors(cells, 0, 4, 4, 1.5).sort()).toEqual([1, 4, 5]);
-    expect(getGridCellNeighbors(cells, 5, 4, 4, 1.5).sort()).toEqual([0, 1, 2, 4, 6, 8]);
-    expect(getGridCellNeighbors(cells, 5, 4, 4, 2.5).sort()).toEqual([0, 1, 12, 2, 3, 4, 6, 7, 8]);
-    expect(getGridCellNeighbors(cells, 14, 4, 4, 2.5).sort()).toEqual([12, 13, 15]);
-    expect(getGridCellNeighbors(cells, 15, 4, 4, 2.5).sort()).toEqual([13, 14]);
+    expect(getGridCellNeighbors(cells, 0, 4, 4, 1.5, BurnIndex.Low).sort()).toEqual([1, 4, 5]);
+    expect(getGridCellNeighbors(cells, 5, 4, 4, 1.5, BurnIndex.Low).sort()).toEqual([0, 1, 2, 4, 6, 8]);
+    expect(getGridCellNeighbors(cells, 5, 4, 4, 2.5, BurnIndex.Low).sort()).toEqual([0, 1, 12, 2, 3, 4, 6, 7, 8]);
+    expect(getGridCellNeighbors(cells, 14, 4, 4, 2.5, BurnIndex.Low).sort()).toEqual([12, 13, 15]);
+    expect(getGridCellNeighbors(cells, 15, 4, 4, 2.5, BurnIndex.Low).sort()).toEqual([13, 14]);
   });
 });
 


### PR DESCRIPTION
[#171860513]
[#172003608]

It doesn't give us anything except the initial delay. These properties can be calculated in updateFire method each tick and we won't make a single unnecessary calculation during the whole simulation.

It also makes things much simpler when we need to dynamically change model properties - for example add fire line or change wind speed in the future (Trudi mentioned this idea).