### PR TITLE
Fixes for small window sizes

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -25,6 +25,7 @@
 }
 
 .rightContent{
+  pointer-events: none;
   overflow-x: hidden;
   width: $rightPanelContainerWidth + $tabWidth;
   height: calc(100% - #{$bottomBarHeight + $bottomBarBorderWidth});

--- a/src/components/graph.scss
+++ b/src/components/graph.scss
@@ -5,4 +5,5 @@
   background-color: white;
   border-radius: 5px;
   border: 2px solid $controlGreenDark2;
+  pointer-events: all;
 }

--- a/src/components/simulation-info.scss
+++ b/src/components/simulation-info.scss
@@ -2,9 +2,18 @@
 
 .simulationInfo{
   height: 0;
+  width: 80%;
+  margin-left: auto;
+  margin-right: auto;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: center;
   .zone{
-    position: absolute;
-    top: 34px;
+    display: flex;
+    margin: 10px;
+    margin-left: auto;
+    margin-right: auto;
     width: 124px;
     height: 34px;
     border-radius: 4px;
@@ -21,24 +30,6 @@
     &.zone3{
       background-color: $zone3Orange;
     }
-    &.twoZoneLeft{
-      left: 30%;
-    }
-    &.twoZoneRight{
-      right: 30%;
-    }
-    &.threeZoneLeft{
-      left: 20%;
-    }
-    &.threeZoneMid{
-      position: relative;
-      margin-left: auto;
-      margin-right: auto;
-    }
-    &.threeZoneRight{
-      right: 20%;
-    }
-
     .icon{
       width: 28px;
       height: 28px;

--- a/src/components/simulation-info.tsx
+++ b/src/components/simulation-info.tsx
@@ -16,13 +16,10 @@ const cssClasses = [css.zone1, css.zone2, css.zone3];
 
 const zoneDetails = (zones: Zone[]) => {
   const detailView: any[] = [];
-  const zoneLayout = zones.length === 2 ?
-    [css.twoZoneLeft, css.twoZoneRight] :
-    [css.threeZoneLeft, css.threeZoneMid, css.threeZoneRight];
 
   zones.forEach((z, i) => {
     detailView.push(
-      <div className={`${css.zone} ${zoneLayout[i]} ${cssClasses[i]}`} key={i}>
+      <div className={`${css.zone} ${cssClasses[i]}`} key={i}>
         <div className={`${css.icon} ${css.vegetationIcon}`}>{vegetationIcons[z.vegetation]}</div>
         <div className={`${css.icon} ${css.droughtIcon}`}>{droughtIcons[z.droughtLevel]}</div>
         <div className={`${css.zoneText}`}>

--- a/src/components/terrain-panel.scss
+++ b/src/components/terrain-panel.scss
@@ -1,10 +1,10 @@
 @import "common.scss";
 
 .terrain{
-  position: fixed;
-  top: 100px;
+  position: absolute;
+  top: 10%;
   width: 288px;
-  height: 500px;
+  height: 476px;
   left: 39%;
   margin-left: auto;
   margin-right: auto;
@@ -15,6 +15,7 @@
   background: rgba(255, 255, 255, 1);
   padding: 5px;
   text-align: center;
+  z-index: 2;
 
   &.disabled{
     display: none;
@@ -65,7 +66,7 @@
   }
   .instructions{
     margin-top: 10px;
-    margin-bottom: 13px;
+    margin-bottom: 10px;
     width: 100%;
     text-align: left;
     font-style: italic;
@@ -105,7 +106,7 @@
 
   }
   .terrainSelector{
-    height: 56px;
+    height: 35px;
   }
   .terrainTypeLabels{
     width: 100%;


### PR DESCRIPTION
Removes the invisible box that was in the way due to the graph panel addition
Reduced height of terrain panel and repositioned that and the simulation information boxes at the top of the screen to be better positioned at reduced screen sizes (and still remain well-positioned at higher resolutions)
[#172081678]