### PR TITLE
Add two url parameters to disable Fire Line and Helitack functionality

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -69,6 +69,9 @@ export interface ISimulationConfig {
   // River color, RGBA values (range: [0, 1]). Suggested colors:
   // [0.663,0.855,1,1], [0.337,0.69,0.957,1] or [0.067,0.529,0.882,1]
   riverColor: [number, number, number, number];
+  // Authors may want to disable the fireline and helitack features completely
+  fireLineAvailable: boolean;
+  helitackAvailable: boolean;
 }
 
 export interface IUrlConfig extends ISimulationConfig {
@@ -133,7 +136,9 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   unburntIslandProbability: 0.5, // [0, 1]
   droughtIndexLocked: false,
   severeDroughtAvailable: false,
-  riverColor: [0.067, 0.529, 0.882, 1]
+  riverColor: [0.067, 0.529, 0.882, 1],
+  fireLineAvailable: true,
+  helitackAvailable: true
 });
 
 const getURLParam = (name: string) => {

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -75,12 +75,22 @@ export class SimulationModel {
 
   @computed public get canAddFireLineMarker() {
     // Only one fire line can be added at given time.
-    return this.fireLineMarkers.length < 2 && this.time - this.lastFireLineTimestamp > this.config.fireLineDelay;
+    if (!this.config.fireLineAvailable) {
+      return false;
+    }
+    else {
+      return this.fireLineMarkers.length < 2 && this.time - this.lastFireLineTimestamp > this.config.fireLineDelay;
+    }
   }
 
   @computed public get canUseHelitack() {
-    // Helitack has waiting period before it can be used subsequent times
-    return this.time - this.lastHelitackTimestamp > this.config.helitackDelay;
+    if (!this.config.helitackAvailable) {
+      return false;
+    }
+    else {
+      // Helitack has waiting period before it can be used subsequent times
+      return this.time - this.lastHelitackTimestamp > this.config.helitackDelay;
+    }
   }
 
   public getZoneBurnPercentage(zoneIdx: number) {


### PR DESCRIPTION
Two parameters are: 
helitackAvailable
fireLineAvailable

default is `true`

https://wildfire.concord.org/branch/url-parameters/index.html?helitackAvailable=false&fireLineAvailable=false

[#169958444] [#171027643]