### PR TITLE
Update forest labels, add URL param, update presets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ cache:
   npm: true
 install:
 - travis_retry gem install s3_website -v 3.4.0
-- travis_retry pip install awscli --upgrade --user
 - travis_retry npm ci
 - travis_retry cypress install
 script:

--- a/s3_deploy.sh
+++ b/s3_deploy.sh
@@ -54,6 +54,4 @@ mv $SRC_DIR $DEPLOY_DEST
 # deploy the site contents
 s3_website push --site _site
 
-# explicit CloudFront invalidation to workaround s3_website gem invalidation bug
-# with origin path (https://github.com/laurilehmijoki/s3_website/issues/207).
-aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths $INVAL_PATH
+JAVA_TOOL_OPTIONS="-Xms1g -Xmx2g" s3_website push --site _site

--- a/src/components/terrain-panel.test.tsx
+++ b/src/components/terrain-panel.test.tsx
@@ -8,7 +8,7 @@ import { Vegetation, TerrainType } from "../types";
 
 const defaultTwoZones = [
   {
-    vegetation: Vegetation.ForestSmallLitter,
+    vegetation: Vegetation.Forest,
     moistureContent: 0.07,
     droughtLevel: 2,
     terrainType: TerrainType.Mountains
@@ -23,7 +23,7 @@ const defaultTwoZones = [
 
 const defaultThreeZones = [
   {
-    vegetation: Vegetation.ForestSmallLitter,
+    vegetation: Vegetation.Forest,
     moistureContent: 0.07,
     droughtLevel: 2,
     terrainType: TerrainType.Mountains
@@ -35,7 +35,7 @@ const defaultThreeZones = [
     terrainType: TerrainType.Plains
   },
   {
-    vegetation: Vegetation.ForestLargeLitter,
+    vegetation: Vegetation.ForestWithSuppression,
     moistureContent: 0.21,
     droughtLevel: 0,
     terrainType: TerrainType.Foothills

--- a/src/components/terrain-panel.tsx
+++ b/src/components/terrain-panel.tsx
@@ -78,7 +78,7 @@ export class TerrainPanel extends BaseComponent<IProps, IState> {
                   <VegetationSelector
                     vegetation={displayVegetationType}
                     terrainType={zone.terrainType}
-                    onChange={this.handleVegetationChange} 
+                    onChange={this.handleVegetationChange}
                     forestWithSuppressionAvailable={config.forestWithSuppressionAvailable}
                   />
                 </div>

--- a/src/components/terrain-panel.tsx
+++ b/src/components/terrain-panel.tsx
@@ -151,9 +151,9 @@ export class TerrainPanel extends BaseComponent<IProps, IState> {
       // Switching to Mountain terrain changes land type / vegetation options
       // but keeping the min / max options the same for each range helps with slider rendering.
       // Accommodate this by manual adjustment of land types when switching to-from mountain
-      if (newTerrainType !== TerrainType.Mountains && currentZone.vegetation === Vegetation.ForestLargeLitter) {
+      if (newTerrainType !== TerrainType.Mountains && currentZone.vegetation === Vegetation.ForestWithSuppression) {
         // switching from Mountains with large forests to lower land type, reduce forest size
-        simulation.updateZoneVegetation(this.state.selectedZone, Vegetation.ForestSmallLitter);
+        simulation.updateZoneVegetation(this.state.selectedZone, Vegetation.Forest);
       } else if (newTerrainType === TerrainType.Mountains && currentZone.vegetation === Vegetation.Grass) {
         // no grass allowed on mountains, switch to shrubs
         simulation.updateZoneVegetation(this.state.selectedZone, Vegetation.Shrub);

--- a/src/components/terrain-panel.tsx
+++ b/src/components/terrain-panel.tsx
@@ -78,7 +78,9 @@ export class TerrainPanel extends BaseComponent<IProps, IState> {
                   <VegetationSelector
                     vegetation={displayVegetationType}
                     terrainType={zone.terrainType}
-                    onChange={this.handleVegetationChange} />
+                    onChange={this.handleVegetationChange} 
+                    forestWithSuppressionAvailable={config.forestWithSuppressionAvailable}
+                  />
                 </div>
                 <div className={css.selector}>
                   <DroughtSelector

--- a/src/components/vegetation-selector.tsx
+++ b/src/components/vegetation-selector.tsx
@@ -21,7 +21,7 @@ const getIcons = (terrainType: TerrainType, forestWithSuppressionAvailable: bool
       // no grass, no forest with suppression
       return vegetationIcons.slice(1, 3);
     }
-  } 
+  }
   // no forest with suppression
   return vegetationIcons.slice(0, 3);
 }
@@ -35,7 +35,7 @@ const getMarks = (terrainType: TerrainType, forestWithSuppressionAvailable: bool
       // no grass, no forest with suppression
       return generateMarks(vegetationLabels.slice(1, 3));
     }
-  } 
+  }
   // no forest with suppression
   return generateMarks(vegetationLabels.slice(0, 3));
 }
@@ -48,12 +48,12 @@ export const VegetationSelector = ({ vegetation, terrainType, onChange, forestWi
       <div className={css.header}>Vegetation Type</div>
       <div className={css.sliderContainer}>
         <div className={css.sliderIcons}>
-          { 
-            icons.map((icon, idx) => 
+          {
+            icons.map((icon, idx) =>
               <div key={idx} className={`${css.sliderIcon} ${css.placeholder} ${idx === 0 ? css.bottom : (idx === icons.length - 1 ? css.top : css.mid)}`}>
                 { icon }
               </div>
-            ) 
+            )
           }
         </div>
         <Slider

--- a/src/components/vegetation-selector.tsx
+++ b/src/components/vegetation-selector.tsx
@@ -1,34 +1,60 @@
 import React from "react";
 import { Slider } from "@material-ui/core";
 import VerticalHandle from "../assets/slider-vertical.svg";
-import { TerrainType } from "../types";
+import { TerrainType, Vegetation } from "../types";
 import { vegetationLabels, generateMarks, vegetationIcons } from "./vertical-selectors";
 import * as css from "./vertical-selectors.scss";
 
 interface IProps {
-  vegetation: number;
-  terrainType: number;
+  vegetation: Vegetation;
+  terrainType: TerrainType;
   onChange?: any;
+  forestWithSuppressionAvailable: boolean;
 }
 
-const iconsMountains = [
-  <div className={`${css.sliderIcon} ${css.shrub} ${css.bottom} ${css.placeholder}`} key={0}>{vegetationIcons[1]}</div>,
-  <div className={`${css.sliderIcon} ${css.fsl} ${css.mid} ${css.placeholder}`} key={1} >{vegetationIcons[2]}</div>,
-  <div className={`${css.sliderIcon} ${css.fll} ${css.top} ${css.placeholder}`} key={2} >{vegetationIcons[3]}</div>
-];
-const icons = [
-  <div className={`${css.sliderIcon} ${css.grass} ${css.bottom} ${css.placeholder}`} key={0}>{vegetationIcons[0]}</div>,
-  <div className={`${css.sliderIcon} ${css.shrub} ${css.mid} ${css.placeholder}`} key={1} >{vegetationIcons[1]}</div>,
-  <div className={`${css.sliderIcon} ${css.fsl} ${css.top} ${css.placeholder}`} key={2}>{vegetationIcons[2]}</div>
-];
+const getIcons = (terrainType: TerrainType, forestWithSuppressionAvailable: boolean) => {
+  if (terrainType === TerrainType.Mountains) {
+    if (forestWithSuppressionAvailable) {
+      // no grass
+      return vegetationIcons.slice(1);
+    } else {
+      // no grass, no forest with suppression
+      return vegetationIcons.slice(1, 3);
+    }
+  } 
+  // no forest with suppression
+  return vegetationIcons.slice(0, 3);
+}
 
-export const VegetationSelector = ({ vegetation: vegetationType, terrainType, onChange }: IProps) =>
-  (
+const getMarks = (terrainType: TerrainType, forestWithSuppressionAvailable: boolean) => {
+  if (terrainType === TerrainType.Mountains) {
+    if (forestWithSuppressionAvailable) {
+      // no grass
+      return generateMarks(vegetationLabels.slice(1));
+    } else {
+      // no grass, no forest with suppression
+      return generateMarks(vegetationLabels.slice(1, 3));
+    }
+  } 
+  // no forest with suppression
+  return generateMarks(vegetationLabels.slice(0, 3));
+}
+
+export const VegetationSelector = ({ vegetation, terrainType, onChange, forestWithSuppressionAvailable }: IProps) => {
+  const marks = getMarks(terrainType, forestWithSuppressionAvailable);
+  const icons = getIcons(terrainType, forestWithSuppressionAvailable);
+  return (
     <div className={`${css.selector} ${css.vegetation}`}>
       <div className={css.header}>Vegetation Type</div>
       <div className={css.sliderContainer}>
         <div className={css.sliderIcons}>
-          { terrainType === TerrainType.Mountains ? iconsMountains : icons }
+          { 
+            icons.map((icon, idx) => 
+              <div key={idx} className={`${css.sliderIcon} ${css.placeholder} ${idx === 0 ? css.bottom : (idx === icons.length - 1 ? css.top : css.mid)}`}>
+                { icon }
+              </div>
+            ) 
+          }
         </div>
         <Slider
           classes={{
@@ -40,12 +66,11 @@ export const VegetationSelector = ({ vegetation: vegetationType, terrainType, on
             disabled: css.disabled
           }}
           min={0}
-          max={2}
-          value={vegetationType}
+          max={marks.length - 1}
+          value={vegetation}
           step={1}
           track={false}
-          marks={terrainType === TerrainType.Mountains ?
-            generateMarks(vegetationLabels.slice(1)) : generateMarks(vegetationLabels.slice(0, 3))}
+          marks={marks}
           onChange={onChange}
           orientation="vertical"
           ThumbComponent={VerticalHandle}
@@ -55,3 +80,4 @@ export const VegetationSelector = ({ vegetation: vegetationType, terrainType, on
       </div>
     </div>
   );
+};

--- a/src/components/vertical-selectors.tsx
+++ b/src/components/vertical-selectors.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import Grass from "../assets/terrain/vegetation-grass.svg";
 import Shrub from "../assets/terrain/vegetation-shrub.svg";
-import ForestSmallLitter from "../assets/terrain/vegetation-fsl.svg";
-import ForestLargeLitter from "../assets/terrain/vegetation-fll.svg";
+import Forest from "../assets/terrain/vegetation-fsl.svg";
+import ForestWithSuppression from "../assets/terrain/vegetation-fll.svg";
 
 import NoDrought from "../assets/terrain/drought-no.svg";
 import MildDrought from "../assets/terrain/drought-mild.svg";
@@ -12,8 +12,8 @@ import SevereDrought from "../assets/terrain/drought-severe.svg";
 export const vegetationLabels = [
   "Grass",
   "Shrub",
-  "Forest Small Litter",
-  "Forest Large Litter"
+  "Forest",
+  "Forest With Suppression"
 ];
 
 export const droughtLabels = [
@@ -34,8 +34,8 @@ export const generateMarks = (labelsToShow: string[]) => {
 export const vegetationIcons = [
   <Grass key={0} />,
   <Shrub key={1} />,
-  <ForestSmallLitter key={2} />,
-  <ForestLargeLitter key={3} />
+  <Forest key={2} />,
+  <ForestWithSuppression key={3} />
 ];
 
 export const droughtIcons = [

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,7 +117,7 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
     },
     {
       terrainType: TerrainType.Plains,
-      vegetation: Vegetation.ForestSmallLitter,
+      vegetation: Vegetation.Forest,
       droughtLevel: DroughtLevel.SevereDrought
     }
   ],

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,7 @@ export interface ISimulationConfig {
   // Authors may want to disable the fireline and helitack features completely
   fireLineAvailable: boolean;
   helitackAvailable: boolean;
+  forestWithSuppressionAvailable: boolean;
 }
 
 export interface IUrlConfig extends ISimulationConfig {
@@ -138,7 +139,8 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   severeDroughtAvailable: false,
   riverColor: [0.067, 0.529, 0.882, 1],
   fireLineAvailable: true,
-  helitackAvailable: true
+  helitackAvailable: true,
+  forestWithSuppressionAvailable: false
 });
 
 const getURLParam = (name: string) => {

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -102,13 +102,13 @@ export class Cell {
       }
       return BurnIndex.High;
     }
-    if (this.vegetation === Vegetation.ForestSmallLitter) {
+    if (this.vegetation === Vegetation.Forest) {
       if (this.spreadRate < 25) {
         return BurnIndex.Low;
       }
       return BurnIndex.Medium;
     }
-    // this.vegetation === Vegetation.ForestLargeLitter
+    // this.vegetation === Vegetation.ForestWithSuppression
     if (this.spreadRate < 12) {
       return BurnIndex.Low;
     }

--- a/src/models/engine/get-fire-spread-rate.test.ts
+++ b/src/models/engine/get-fire-spread-rate.test.ts
@@ -57,9 +57,9 @@ describe("getFireSpreadRate", () => {
     expect(getFireSpreadRate(sourceCell, targetCell, { speed: 20, direction: 0 }, cellSize)).toBeCloseTo(541.68779579);
   });
 
-  it("calculates the fireSpreadRate correctly for forest small litter fuel type", () => {
-    sourceCell.vegetation = Vegetation.ForestSmallLitter;
-    targetCell.vegetation = Vegetation.ForestSmallLitter;
+  it("calculates the fireSpreadRate correctly for forest fuel type", () => {
+    sourceCell.vegetation = Vegetation.Forest;
+    targetCell.vegetation = Vegetation.Forest;
     // Note that result is taken from:
     // https://drive.google.com/file/d/1ck0nwlawOtK-GjCV4qJ6ztMcxh3utbv-/view?usp=sharing
     // cells F13:
@@ -72,9 +72,9 @@ describe("getFireSpreadRate", () => {
     expect(getFireSpreadRate(sourceCell, targetCell, { speed: 20, direction: 0 }, cellSize)).toBeCloseTo(64.40222588);
   });
 
-  it("calculates the fireSpreadRate correctly for forest large litter fuel type", () => {
-    sourceCell.vegetation = Vegetation.ForestLargeLitter;
-    targetCell.vegetation = Vegetation.ForestLargeLitter;
+  it("calculates the fireSpreadRate correctly for forest with suppression fuel type", () => {
+    sourceCell.vegetation = Vegetation.ForestWithSuppression;
+    targetCell.vegetation = Vegetation.ForestWithSuppression;
     // Note that result is taken from:
     // https://drive.google.com/file/d/1ck0nwlawOtK-GjCV4qJ6ztMcxh3utbv-/view?usp=sharing
     // cells F13:

--- a/src/models/engine/get-fire-spread-rate.ts
+++ b/src/models/engine/get-fire-spread-rate.ts
@@ -32,14 +32,14 @@ const FuelConstants: {[key in Vegetation]: Fuel} = {
   },
   // TODO: the following two land types have not yet been configured via specification,
   // only by approximation to get the code to compile
-  [Vegetation.ForestSmallLitter]: {
+  [Vegetation.Forest]: {
     sav: 1716,
     netFuelLoad: 0.0459,
     fuelBedDepth: 0.1,
     packingRatio: 0.04878,
     mx: 0.2
   },
-  [Vegetation.ForestLargeLitter]: {
+  [Vegetation.ForestWithSuppression]: {
     sav: 1500,
     netFuelLoad: 0.689,
     fuelBedDepth: 0.5,

--- a/src/models/zone.ts
+++ b/src/models/zone.ts
@@ -7,7 +7,7 @@ export interface ZoneOptions {
   droughtLevel?: number;
 }
 
-// values for each level of vegetation: Grass, Shrub, ForestSmallLitter, ForestLargeLitter
+// values for each level of vegetation: Grass, Shrub, Forest, ForestWithSuppression
 export const moistureLookups: {[key in DroughtLevel]: number[]} = {
   [DroughtLevel.NoDrought]: [0.1275, 0.255, 0.17, 0.2125],
   [DroughtLevel.MildDrought]: [0.09, 0.18, 0.12, 0.15],

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -139,7 +139,7 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
   dryTownsThreeZone: {
     zonesCount: 3,
     zones: [
-      { terrainType: TerrainType.Mountains, vegetation: Vegetation.ForestLargeLitter, droughtLevel: 1 },
+      { terrainType: TerrainType.Mountains, vegetation: Vegetation.ForestWithSuppression, droughtLevel: 1 },
       { terrainType: TerrainType.Foothills, vegetation: Vegetation.Shrub, droughtLevel: 2 },
       { terrainType: TerrainType.Plains, vegetation: Vegetation.Shrub, droughtLevel: 2 },
     ],
@@ -155,7 +155,7 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
   defaultThreeZone: {
     zonesCount: 3,
     zones: [
-      { terrainType: TerrainType.Mountains, vegetation: Vegetation.ForestLargeLitter, droughtLevel: 0 },
+      { terrainType: TerrainType.Mountains, vegetation: Vegetation.ForestWithSuppression, droughtLevel: 0 },
       { terrainType: TerrainType.Foothills, vegetation: Vegetation.Shrub, droughtLevel: 1 },
       { terrainType: TerrainType.Plains, vegetation: Vegetation.Grass, droughtLevel: 2 },
     ],
@@ -173,7 +173,7 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
     zones: [
       { terrainType: TerrainType.Plains, vegetation: Vegetation.Grass, droughtLevel: 3 },
       { terrainType: TerrainType.Plains, vegetation: Vegetation.Shrub, droughtLevel: 2 },
-      { terrainType: TerrainType.Plains, vegetation: Vegetation.ForestSmallLitter, droughtLevel: 0 },
+      { terrainType: TerrainType.Plains, vegetation: Vegetation.Forest, droughtLevel: 0 },
     ],
     zoneIndex: [
       [ 0, 1, 2 ]
@@ -195,7 +195,7 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
     zones: [
       { terrainType: TerrainType.Foothills, vegetation: Vegetation.Grass, droughtLevel: 1 },
       { terrainType: TerrainType.Foothills, vegetation: Vegetation.Shrub, droughtLevel: 1 },
-      { terrainType: TerrainType.Foothills, vegetation: Vegetation.ForestSmallLitter, droughtLevel: 1 },
+      { terrainType: TerrainType.Foothills, vegetation: Vegetation.Forest, droughtLevel: 1 },
     ],
     zoneIndex: [
       [ 0, 1, 2 ]
@@ -216,8 +216,8 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
     zonesCount: 3,
     zones: [
       { terrainType: TerrainType.Mountains, vegetation: Vegetation.Shrub, droughtLevel: 1 },
-      { terrainType: TerrainType.Mountains, vegetation: Vegetation.ForestSmallLitter, droughtLevel: 1 },
-      { terrainType: TerrainType.Mountains, vegetation: Vegetation.ForestLargeLitter, droughtLevel: 1 },
+      { terrainType: TerrainType.Mountains, vegetation: Vegetation.Forest, droughtLevel: 1 },
+      { terrainType: TerrainType.Mountains, vegetation: Vegetation.ForestWithSuppression, droughtLevel: 1 },
     ],
     zoneIndex: [
       [ 0, 1, 2 ]
@@ -228,7 +228,7 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
     zones: [
       { terrainType: TerrainType.Mountains, vegetation: Vegetation.Grass, droughtLevel: 3 },
       { terrainType: TerrainType.Foothills, vegetation: Vegetation.Shrub, droughtLevel: 3 },
-      { terrainType: TerrainType.Plains, vegetation: Vegetation.ForestSmallLitter, droughtLevel: 3 },
+      { terrainType: TerrainType.Plains, vegetation: Vegetation.Forest, droughtLevel: 3 },
     ],
     zoneIndex: [
       [ 0, 1, 2 ]
@@ -239,7 +239,7 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
     zones: [
       {
         terrainType: TerrainType.Mountains,
-        vegetation: Vegetation.ForestLargeLitter,
+        vegetation: Vegetation.ForestWithSuppression,
         droughtLevel: DroughtLevel.MediumDrought
       },
       {
@@ -316,7 +316,7 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
     zones: [
       { terrainType: TerrainType.Mountains, vegetation: Vegetation.Grass, droughtLevel: 3 },
       { terrainType: TerrainType.Foothills, vegetation: Vegetation.Shrub, droughtLevel: 3 },
-      { terrainType: TerrainType.Plains, vegetation: Vegetation.ForestSmallLitter, droughtLevel: 3 },
+      { terrainType: TerrainType.Plains, vegetation: Vegetation.Forest, droughtLevel: 3 },
     ],
     zoneIndex: [
       [ 0, 1, 2 ]

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -139,7 +139,7 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
   dryTownsThreeZone: {
     zonesCount: 3,
     zones: [
-      { terrainType: TerrainType.Mountains, vegetation: Vegetation.ForestWithSuppression, droughtLevel: 1 },
+      { terrainType: TerrainType.Mountains, vegetation: Vegetation.Forest, droughtLevel: 1 },
       { terrainType: TerrainType.Foothills, vegetation: Vegetation.Shrub, droughtLevel: 2 },
       { terrainType: TerrainType.Plains, vegetation: Vegetation.Shrub, droughtLevel: 2 },
     ],
@@ -155,7 +155,7 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
   defaultThreeZone: {
     zonesCount: 3,
     zones: [
-      { terrainType: TerrainType.Mountains, vegetation: Vegetation.ForestWithSuppression, droughtLevel: 0 },
+      { terrainType: TerrainType.Mountains, vegetation: Vegetation.Forest, droughtLevel: 0 },
       { terrainType: TerrainType.Foothills, vegetation: Vegetation.Shrub, droughtLevel: 1 },
       { terrainType: TerrainType.Plains, vegetation: Vegetation.Grass, droughtLevel: 2 },
     ],
@@ -217,7 +217,7 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
     zones: [
       { terrainType: TerrainType.Mountains, vegetation: Vegetation.Shrub, droughtLevel: 1 },
       { terrainType: TerrainType.Mountains, vegetation: Vegetation.Forest, droughtLevel: 1 },
-      { terrainType: TerrainType.Mountains, vegetation: Vegetation.ForestWithSuppression, droughtLevel: 1 },
+      { terrainType: TerrainType.Mountains, vegetation: Vegetation.Forest, droughtLevel: 1 },
     ],
     zoneIndex: [
       [ 0, 1, 2 ]
@@ -239,7 +239,7 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
     zones: [
       {
         terrainType: TerrainType.Mountains,
-        vegetation: Vegetation.ForestWithSuppression,
+        vegetation: Vegetation.Forest,
         droughtLevel: DroughtLevel.MediumDrought
       },
       {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,8 @@ export interface Town {
 export enum Vegetation {
   Grass = 0,
   Shrub = 1,
-  ForestSmallLitter = 2,
-  ForestLargeLitter = 3
+  Forest = 2,
+  ForestWithSuppression = 3
 }
 
 export enum TerrainType {


### PR DESCRIPTION
- forest with small litter => forest
- forest with large litter => forest with suppression 
- forest with suppression is not available by default, there's a new URL param: `forestWithSuppressionAvailable`
- a small cleanup of vegetation-selector
- all the presets that were using forest with large litter are now using regular forest (as forest with suppression is not available by default)