### PR TITLE
Some of the forest simulation cells should survive the fire

### DIFF
--- a/src/components/view-3d/terrain.tsx
+++ b/src/components/view-3d/terrain.tsx
@@ -34,7 +34,7 @@ const BURNT_COLOR = [0.2, 0.2, 0.2, 1];
 const FIRE_LINE_UNDER_CONSTRUCTION_COLOR = [0.5, 0.5, 0, 1];
 
 const BURN_INDEX_LOW = [1, 0.7, 0, 1];
-const BURN_INDEX_MEDIUM = [1, 0.35, 0, 1];
+const BURN_INDEX_MEDIUM = [1, 0.5, 0, 1];
 const BURN_INDEX_HIGH = [1, 0, 0, 1];
 
 const burnIndexColor = (burnIndex: BurnIndex) => {

--- a/src/components/view-3d/terrain.tsx
+++ b/src/components/view-3d/terrain.tsx
@@ -55,7 +55,7 @@ const setVertexColor = (
   if (cell.fireState === FireState.Burning) {
     color = config.showBurnIndex ? burnIndexColor(cell.burnIndex) : BURNING_COLOR;
   } else if (cell.fireState === FireState.Burnt) {
-    color = BURNT_COLOR;
+    color = cell.isFireSurvivor ? getTerrainColor(cell.droughtLevel) : BURNT_COLOR;
   } else if (cell.isRiver) {
     color = config.riverColor;
   } else if (cell.isFireLineUnderConstruction) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,9 @@ export interface ISimulationConfig {
   // Number between 0 and 1 which decides how likely is for unburnt island to form (as it's random).
   // 1 means that all the unburnt islands will be visible, 0 means that none of them will be visible.
   unburntIslandProbability: number;
+  // Number between 0 and 1 which decides how likely is for a cells to survive fire. Note that there are other factors
+  // too. The only vegetation that can survive fire low and medium intensity fire is `Forest`.
+  fireSurvivalProbability: number;
   // Locks drought index slider in Terrain Setup dialog.
   droughtIndexLocked: boolean;
   // Makes severe drought option available in Terrain Setup dialog.

--- a/src/config.ts
+++ b/src/config.ts
@@ -135,12 +135,13 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   showBurnIndex: false,
   showCoordsOnClick: false,
   unburntIslandProbability: 0.5, // [0, 1]
+  fireSurvivalProbability: 0.1, // [0, 1]
   droughtIndexLocked: false,
   severeDroughtAvailable: false,
   riverColor: [0.067, 0.529, 0.882, 1],
   fireLineAvailable: true,
   helitackAvailable: true,
-  forestWithSuppressionAvailable: false
+  forestWithSuppressionAvailable: false,
 });
 
 const getURLParam = (name: string) => {

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -42,6 +42,7 @@ export class Cell {
   public burnTime: number = MAX_BURN_TIME;
   public fireState: FireState = FireState.Unburnt;
   public isUnburntIsland: boolean = false;
+  public isFireSurvivor: boolean = false;
   public isRiver: boolean = false;
   public isFireLine: boolean = false;
   public isFireLineUnderConstruction: boolean = false;
@@ -83,6 +84,10 @@ export class Cell {
 
   public get isBurningOrWillBurn() {
     return this.fireState === FireState.Burning || this.fireState === FireState.Unburnt && this.ignitionTime < Infinity;
+  }
+
+  public get canSurviveFire() {
+    return this.burnIndex === BurnIndex.Low && this.vegetation === Vegetation.Forest;
   }
 
   public get burnIndex() {
@@ -131,5 +136,6 @@ export class Cell {
     this.isFireLineUnderConstruction = false;
     this.isFireLine = false;
     this.helitackDropCount = 0;
+    this.isFireSurvivor = false;
   }
 }

--- a/src/models/engine/fire-engine.ts
+++ b/src/models/engine/fire-engine.ts
@@ -76,6 +76,7 @@ export interface IFireEngineConfig {
   cellSize: number;
   minCellBurnTime: number;
   neighborsDist: number;
+  fireSurvivalProbability: number;
 }
 
 // Lightweight helper that is responsible only for math calculations. It's not bound to MobX or any UI state
@@ -89,6 +90,7 @@ export class FireEngine {
   public cellSize: number;
   public minCellBurnTime: number;
   public neighborsDist: number;
+  public fireSurvivalProbability: number;
   public endOfLowIntensityFire = false;
   public fireDidStop = false;
   public day: number = 0;
@@ -102,6 +104,7 @@ export class FireEngine {
     this.cellSize = config.cellSize;
     this.minCellBurnTime = config.minCellBurnTime;
     this.neighborsDist = config.neighborsDist;
+    this.fireSurvivalProbability = config.fireSurvivalProbability;
 
     // Use sparks to start the simulation.
     sparks.forEach(spark => {
@@ -166,6 +169,9 @@ export class FireEngine {
       const ignitionTime = cell.ignitionTime;
       if (cell.fireState === FireState.Burning && time - ignitionTime > cell.burnTime) {
         newFireStateData[i] = FireState.Burnt;
+        if (cell.canSurviveFire && Math.random() < this.fireSurvivalProbability) {
+          cell.isFireSurvivor = true;
+        }
       } else if (cell.fireState === FireState.Unburnt && time > ignitionTime ) {
         // Sets any unburnt cells to burning if we are passed their ignition time.
         // Although during a simulation all cells will have their state sent to BURNING through the process


### PR DESCRIPTION
Example below:
<img width="1121" alt="Screenshot 2021-07-22 at 11 34 08" src="https://user-images.githubusercontent.com/767857/126624585-39314c9e-dac2-4ce5-8a74-a03c7ce37e38.png">
Note that there are green pixels visible in the burnt area. This is applied only to forests (requirement from the project team).

There's also a new URL param to control how many cells survive the fire: `fireSurvivalProbability`.

