### PR TITLE
fix: fix color management [PT-185278825]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.3",
-        "@react-three/drei": "^9.70.3",
+        "@react-three/drei": "^9.72.2",
         "@react-three/fiber": "^8.13.0",
         "@svgr/webpack": "^8.0.1",
         "babel-core": "^6.26.3",
@@ -58,7 +58,7 @@
         "babel-jest": "^29.5.0",
         "css-loader": "^6.8.1",
         "cypress": "12.13.0",
-        "eslint": "^8.41.0",
+        "eslint": "^8.42.0",
         "eslint-config-react": "^1.1.7",
         "eslint-import-resolver-typescript": "^3.5.5",
         "eslint-plugin-chai-friendly": "^0.7.2",
@@ -88,7 +88,7 @@
         "typescript": "^5.1.3",
         "url-loader": "^4.1.1",
         "webpack": "^5.85.0",
-        "webpack-cli": "^5.1.1",
+        "webpack-cli": "^5.1.3",
         "webpack-dev-server": "^4.15.0"
       }
     },
@@ -2400,9 +2400,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.41.0.tgz",
-      "integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
+      "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3703,9 +3703,9 @@
       "integrity": "sha512-POu8Mk0hIU3lRXB3bGIGe4VHIwwDsQyoD1F394OK7STTiX9w4dG3cTLljjYswkQN+hDSHRrj4O36kuVa7KPU8Q=="
     },
     "node_modules/@react-three/drei": {
-      "version": "9.70.3",
-      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.70.3.tgz",
-      "integrity": "sha512-o1V+cHGVYJwExwlsC6LuBtQ9crtuBmUnr42aDiujCzc4WX4NDRcAPBBi4z9cBlqB7NtsMfh+n8UotXmA3rc4Vg==",
+      "version": "9.72.2",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.72.2.tgz",
+      "integrity": "sha512-isvUnQBvzjFAyGkSUgybYlJT02v3fBrmzE1yxSwx6Olr9jPJNeCFug0jy/CaJknHpV0W2128GpNZjpI4iG/IBg==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@react-spring/three": "~9.6.1",
@@ -5334,9 +5334,9 @@
       }
     },
     "node_modules/@webpack-cli/configtest": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.0.tgz",
-      "integrity": "sha512-K/vuv72vpfSEZoo5KIU0a2FsEoYdW0DUMtMpB5X3LlUwshetMZRZRxB7sCsVji/lFaSxtQQ3aM9O4eMolXkU9w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
+      "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
       "dev": true,
       "engines": {
         "node": ">=14.15.0"
@@ -5347,9 +5347,9 @@
       }
     },
     "node_modules/@webpack-cli/info": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.1.tgz",
-      "integrity": "sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
+      "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
       "dev": true,
       "engines": {
         "node": ">=14.15.0"
@@ -5360,9 +5360,9 @@
       }
     },
     "node_modules/@webpack-cli/serve": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.4.tgz",
-      "integrity": "sha512-0xRgjgDLdz6G7+vvDLlaRpFatJaJ69uTalZLRSMX5B3VUrDmXcrVA3+6fXXQgmYz7bY9AAgs348XQdmtLsK41A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
+      "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
       "dev": true,
       "engines": {
         "node": ">=14.15.0"
@@ -8576,16 +8576,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.41.0.tgz",
-      "integrity": "sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz",
+      "integrity": "sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
         "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.41.0",
-        "@humanwhocodes/config-array": "^0.11.8",
+        "@eslint/js": "8.42.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
@@ -18667,15 +18667,15 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.1.tgz",
-      "integrity": "sha512-OLJwVMoXnXYH2ncNGU8gxVpUtm3ybvdioiTvHgUyBuyMLKiVvWy+QObzBsMtp5pH7qQoEuWgeEUQ/sU3ZJFzAw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.3.tgz",
+      "integrity": "sha512-MTuk7NUMvEHQUSXCpvUrF1q2p0FJS40dPFfqQvG3jTWcgv/8plBNz2Kv2HXZiLGPnfmSAA5uCtCILO1JBmmkfw==",
       "dev": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^2.1.0",
-        "@webpack-cli/info": "^2.0.1",
-        "@webpack-cli/serve": "^2.0.4",
+        "@webpack-cli/configtest": "^2.1.1",
+        "@webpack-cli/info": "^2.0.2",
+        "@webpack-cli/serve": "^2.0.5",
         "colorette": "^2.0.14",
         "commander": "^10.0.1",
         "cross-spawn": "^7.0.3",
@@ -20896,9 +20896,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.41.0.tgz",
-      "integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
+      "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
       "dev": true
     },
     "@hapi/hoek": {
@@ -21784,9 +21784,9 @@
       "integrity": "sha512-POu8Mk0hIU3lRXB3bGIGe4VHIwwDsQyoD1F394OK7STTiX9w4dG3cTLljjYswkQN+hDSHRrj4O36kuVa7KPU8Q=="
     },
     "@react-three/drei": {
-      "version": "9.70.3",
-      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.70.3.tgz",
-      "integrity": "sha512-o1V+cHGVYJwExwlsC6LuBtQ9crtuBmUnr42aDiujCzc4WX4NDRcAPBBi4z9cBlqB7NtsMfh+n8UotXmA3rc4Vg==",
+      "version": "9.72.2",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.72.2.tgz",
+      "integrity": "sha512-isvUnQBvzjFAyGkSUgybYlJT02v3fBrmzE1yxSwx6Olr9jPJNeCFug0jy/CaJknHpV0W2128GpNZjpI4iG/IBg==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "@react-spring/three": "~9.6.1",
@@ -23049,23 +23049,23 @@
       }
     },
     "@webpack-cli/configtest": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.0.tgz",
-      "integrity": "sha512-K/vuv72vpfSEZoo5KIU0a2FsEoYdW0DUMtMpB5X3LlUwshetMZRZRxB7sCsVji/lFaSxtQQ3aM9O4eMolXkU9w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
+      "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
       "dev": true,
       "requires": {}
     },
     "@webpack-cli/info": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.1.tgz",
-      "integrity": "sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
+      "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
       "dev": true,
       "requires": {}
     },
     "@webpack-cli/serve": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.4.tgz",
-      "integrity": "sha512-0xRgjgDLdz6G7+vvDLlaRpFatJaJ69uTalZLRSMX5B3VUrDmXcrVA3+6fXXQgmYz7bY9AAgs348XQdmtLsK41A==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
+      "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
       "dev": true,
       "requires": {}
     },
@@ -25492,16 +25492,16 @@
       }
     },
     "eslint": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.41.0.tgz",
-      "integrity": "sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz",
+      "integrity": "sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
         "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.41.0",
-        "@humanwhocodes/config-array": "^0.11.8",
+        "@eslint/js": "8.42.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
@@ -32850,15 +32850,15 @@
       }
     },
     "webpack-cli": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.1.tgz",
-      "integrity": "sha512-OLJwVMoXnXYH2ncNGU8gxVpUtm3ybvdioiTvHgUyBuyMLKiVvWy+QObzBsMtp5pH7qQoEuWgeEUQ/sU3ZJFzAw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.3.tgz",
+      "integrity": "sha512-MTuk7NUMvEHQUSXCpvUrF1q2p0FJS40dPFfqQvG3jTWcgv/8plBNz2Kv2HXZiLGPnfmSAA5uCtCILO1JBmmkfw==",
       "dev": true,
       "requires": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^2.1.0",
-        "@webpack-cli/info": "^2.0.1",
-        "@webpack-cli/serve": "^2.0.4",
+        "@webpack-cli/configtest": "^2.1.1",
+        "@webpack-cli/info": "^2.0.2",
+        "@webpack-cli/serve": "^2.0.5",
         "colorette": "^2.0.14",
         "commander": "^10.0.1",
         "cross-spawn": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "babel-jest": "^29.5.0",
     "css-loader": "^6.8.1",
     "cypress": "12.13.0",
-    "eslint": "^8.41.0",
+    "eslint": "^8.42.0",
     "eslint-config-react": "^1.1.7",
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-chai-friendly": "^0.7.2",
@@ -116,7 +116,7 @@
     "typescript": "^5.1.3",
     "url-loader": "^4.1.1",
     "webpack": "^5.85.0",
-    "webpack-cli": "^5.1.1",
+    "webpack-cli": "^5.1.3",
     "webpack-dev-server": "^4.15.0"
   },
   "dependencies": {
@@ -125,7 +125,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.3",
-    "@react-three/drei": "^9.70.3",
+    "@react-three/drei": "^9.72.2",
     "@react-three/fiber": "^8.13.0",
     "@svgr/webpack": "^8.0.1",
     "babel-core": "^6.26.3",

--- a/src/components/view-3d/marker.tsx
+++ b/src/components/view-3d/marker.tsx
@@ -18,6 +18,7 @@ const getTexture = (imgSrcOrCanvas: string | HTMLCanvasElement) => {
     Texture = THREE.CanvasTexture;
   }
   const texture = new Texture(source);
+  texture.colorSpace = THREE.SRGBColorSpace;
   return texture;
 };
 

--- a/src/components/view-3d/terrain.tsx
+++ b/src/components/view-3d/terrain.tsx
@@ -19,22 +19,22 @@ const vertexIdx = (cell: Cell, gridWidth: number, gridHeight: number) => (gridHe
 const getTerrainColor = (droughtLevel: number) => {
   switch (droughtLevel) {
     case DroughtLevel.NoDrought:
-      return [0.008, 0.831, 0.039, 1];
+      return [0.008, 0.831, 0.039];
     case DroughtLevel.MildDrought:
-      return [0.573, 0.839, 0.216, 1];
+      return [0.573, 0.839, 0.216];
     case DroughtLevel.MediumDrought:
-      return [0.757, 0.886, 0.271, 1];
+      return [0.757, 0.886, 0.271];
     default:
-      return [0.784, 0.631, 0.271, 1];
+      return [0.784, 0.631, 0.271];
   }
 };
-const BURNING_COLOR = [1, 0, 0, 1];
-const BURNT_COLOR = [0.2, 0.2, 0.2, 1];
-const FIRE_LINE_UNDER_CONSTRUCTION_COLOR = [0.5, 0.5, 0, 1];
+const BURNING_COLOR = [1, 0, 0];
+const BURNT_COLOR = [0.2, 0.2, 0.2];
+const FIRE_LINE_UNDER_CONSTRUCTION_COLOR = [0.5, 0.5, 0];
 
-export const BURN_INDEX_LOW = [1, 0.7, 0, 1];
-export const BURN_INDEX_MEDIUM = [1, 0.5, 0, 1];
-export const BURN_INDEX_HIGH = [1, 0, 0, 1];
+export const BURN_INDEX_LOW = [1, 0.7, 0];
+export const BURN_INDEX_MEDIUM = [1, 0.5, 0];
+export const BURN_INDEX_HIGH = [1, 0, 0];
 
 const burnIndexColor = (burnIndex: BurnIndex) => {
   if (burnIndex === BurnIndex.Low) {
@@ -62,10 +62,17 @@ const setVertexColor = (
   } else {
     color = getTerrainColor(cell.droughtLevel);
   }
-  colArray[idx] = color[0];
-  colArray[idx + 1] = color[1];
-  colArray[idx + 2] = color[2];
-  colArray[idx + 3] = color[3];
+  // Note that we're using sRGB colorspace here (default while working with web). THREE.js needs to operate in linear
+  // color space, so we need to convert it first. See:
+  // https://discourse.threejs.org/t/updates-to-color-management-in-three-js-r152/50791
+  // https://threejs.org/docs/#manual/en/introduction/Color-management
+  const threeJsColor = new THREE.Color();
+  threeJsColor.setRGB(color[0], color[1], color[2], THREE.SRGBColorSpace);
+
+  colArray[idx] = threeJsColor.r;
+  colArray[idx + 1] = threeJsColor.g;
+  colArray[idx + 2] = threeJsColor.b;
+  colArray[idx + 3] = 1; // alpha
 };
 
 const updateColors = (geometry: THREE.PlaneGeometry, simulation: SimulationModel) => {

--- a/src/components/view-3d/view-3d.tsx
+++ b/src/components/view-3d/view-3d.tsx
@@ -53,7 +53,7 @@ export const View3d = () => {
           minAzimuthAngle={-Math.PI * 0.25}
           maxAzimuthAngle={Math.PI * 0.25}
         />
-        <hemisphereLight args={[0xC6C2B6, 0x3A403B, 1.2]} up={DEFAULT_UP}/>
+        <hemisphereLight args={[0xC6C2B6, 0x3A403B, 1]} up={DEFAULT_UP}/>
         <Terrain ref={terrainRef}/>
         <SparksContainer dragPlane={terrainRef}/>
         <FireLineMarkersContainer dragPlane={terrainRef}/>


### PR DESCRIPTION
The recent ThreeJS version changed the approach to color management. It's a large topic described pretty well here:
https://threejs.org/docs/#manual/en/introduction/Color-management
and here are tips related to migration:
https://discourse.threejs.org/t/updates-to-color-management-in-three-js-r152/50791

@tealefristoe, I think I got that working. Long story short, if the color values are provided as hex, we usually don't have to do anything - ThreeJS assumes it's sRGB. But if we deal with [0, 1] and set them directly in attribute arrays, that's the piece where the conversion was missing. We had this case in terrain color and shaders, and it's been updated in thisthis PR. Also, it's necessary to set texture colorspace now, as ThreeJS doesn't make any assumptions. Even though `sRGB` would be true for 99% of basic cases when you just load a regular map. But there are also normal maps, and other kinds of texture that would get broken. I think these changes were introduced in ThreeJS v139 (your case) and then enabled by default in v152 (my case). But maybe a few months ago things were still not polished yet, or there was some conflict between react-three/fiber and ThreeJs.