### PR TITLE
fix: disable tone mapping [PT-185278825]

### DIFF
--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -245,7 +245,6 @@ export class BottomBar extends BaseComponent<IProps, IState> {
   public handleTerrain = () => {
     const { ui } = this.stores;
     ui.showTerrainUI = !ui.showTerrainUI;
-    ui.terrainUISelectedZone = 0;
     log("TerrainPanelButtonClicked");
   };
 

--- a/src/components/simulation-info.test.tsx
+++ b/src/components/simulation-info.test.tsx
@@ -42,10 +42,6 @@ describe("Simulation Info component", () => {
     await userEvent.click(screen.getAllByTestId("zone-info")[2]);
     expect(stores.ui.showTerrainUI).toEqual(true);
     expect(stores.ui.terrainUISelectedZone).toEqual(2);
-
-    // Close terrain panel
-    await userEvent.click(screen.getAllByTestId("zone-info")[2]);
-    expect(stores.ui.showTerrainUI).toEqual(false);
   });
 
   it("locks zone buttons when simulation is started", () => {

--- a/src/components/simulation-info.tsx
+++ b/src/components/simulation-info.tsx
@@ -41,8 +41,6 @@ export const SimulationInfo = observer(function WrappedComponent() {
     if (ui.showTerrainUI === false || ui.terrainUISelectedZone !== zoneIdx) {
       ui.showTerrainUI = true;
       ui.terrainUISelectedZone = zoneIdx;
-    } else {
-      ui.showTerrainUI = false;
     }
     log("ZoneButtonClicked", { zone: zoneIdx });
   };

--- a/src/components/view-3d/view-3d.tsx
+++ b/src/components/view-3d/view-3d.tsx
@@ -35,7 +35,9 @@ export const View3d = () => {
   return (
     /* eslint-disable react/no-unknown-property */
     // See: https://github.com/jsx-eslint/eslint-plugin-react/issues/3423
-    <Canvas camera={{manual: true}}>
+    // flat=true disables tone mapping that is not a default in threejs, but is enabled by default in react-three-fiber.
+    // It makes textures match colors in the original image.
+    <Canvas camera={{manual: true}} flat={true}>
       {/* Why do we need to setup provider again? No idea. It seems that components inside Canvas don't have
           access to MobX stores anymore. */}
       <Provider stores={stores}>
@@ -53,7 +55,7 @@ export const View3d = () => {
           minAzimuthAngle={-Math.PI * 0.25}
           maxAzimuthAngle={Math.PI * 0.25}
         />
-        <hemisphereLight args={[0xC6C2B6, 0x3A403B, 1]} up={DEFAULT_UP}/>
+        <hemisphereLight args={[0xC6C2B6, 0x3A403B, 1.2]} up={DEFAULT_UP}/>
         <Terrain ref={terrainRef}/>
         <SparksContainer dragPlane={terrainRef}/>
         <FireLineMarkersContainer dragPlane={terrainRef}/>

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -484,6 +484,9 @@ export class SimulationModel {
   @action.bound public updateZones(zones: Zone[]) {
     this.zones = zones.map(z => z.clone());
     this.zoneIndex = DEFAULT_ZONE_DIVISION[this.zones.length as (2 | 3)];
+    if (this.sparks.length > this.zones.length) {
+      this.sparks.length = this.zones.length;
+    }
     this.populateCellsData();
   }
 }

--- a/src/models/ui.ts
+++ b/src/models/ui.ts
@@ -10,7 +10,7 @@ export enum Interaction {
 export class UIModel {
   @observable public showChart = false;
   @observable public showTerrainUI = false;
-  @observable public terrainUISelectedZone = 0;
+  @observable public terrainUISelectedZone?: number = undefined;
   @observable public maxSparks: number;
 
   @observable public interaction: Interaction | null = null;


### PR DESCRIPTION
One more piece in the color management saga. When I moved to the Flood model and applied similar updates, I noticed that textures are still a bit off - it's more visible there with a big topo map. Reading this thread: https://github.com/pmndrs/react-three-fiber/issues/1547 I learned that react-three/fiber sets some tone mapping that is not set by ThreeJS. Once I disabled tone mapping, textures look 100% correct. It can be done using `<Canvas flat={true}>` or `Canvas gl={{toneMapping: NoToneMapping}}>`. @tealefristoe, keeping you in the loop so there's a second person who went through this not-so-fun learning process, as it might be confusing in other projects that update or start using ThreeJS and/or react-three/fiber.