### PR TITLE
fix: fix QA issues [PT-171837017]

### DIFF
--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -245,7 +245,6 @@ export class BottomBar extends BaseComponent<IProps, IState> {
   public handleTerrain = () => {
     const { ui } = this.stores;
     ui.showTerrainUI = !ui.showTerrainUI;
-    ui.terrainUISelectedZone = 0;
     log("TerrainPanelButtonClicked");
   };
 

--- a/src/components/simulation-info.test.tsx
+++ b/src/components/simulation-info.test.tsx
@@ -42,10 +42,6 @@ describe("Simulation Info component", () => {
     await userEvent.click(screen.getAllByTestId("zone-info")[2]);
     expect(stores.ui.showTerrainUI).toEqual(true);
     expect(stores.ui.terrainUISelectedZone).toEqual(2);
-
-    // Close terrain panel
-    await userEvent.click(screen.getAllByTestId("zone-info")[2]);
-    expect(stores.ui.showTerrainUI).toEqual(false);
   });
 
   it("locks zone buttons when simulation is started", () => {

--- a/src/components/simulation-info.tsx
+++ b/src/components/simulation-info.tsx
@@ -41,8 +41,6 @@ export const SimulationInfo = observer(function WrappedComponent() {
     if (ui.showTerrainUI === false || ui.terrainUISelectedZone !== zoneIdx) {
       ui.showTerrainUI = true;
       ui.terrainUISelectedZone = zoneIdx;
-    } else {
-      ui.showTerrainUI = false;
     }
     log("ZoneButtonClicked", { zone: zoneIdx });
   };

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -484,6 +484,9 @@ export class SimulationModel {
   @action.bound public updateZones(zones: Zone[]) {
     this.zones = zones.map(z => z.clone());
     this.zoneIndex = DEFAULT_ZONE_DIVISION[this.zones.length as (2 | 3)];
+    if (this.sparks.length > this.zones.length) {
+      this.sparks.length = this.zones.length;
+    }
     this.populateCellsData();
   }
 }

--- a/src/models/ui.ts
+++ b/src/models/ui.ts
@@ -10,7 +10,7 @@ export enum Interaction {
 export class UIModel {
   @observable public showChart = false;
   @observable public showTerrainUI = false;
-  @observable public terrainUISelectedZone = 0;
+  @observable public terrainUISelectedZone?: number = undefined;
   @observable public maxSparks: number;
 
   @observable public interaction: Interaction | null = null;


### PR DESCRIPTION
This PR fixes two issues found during QA:

> In the first panel, select 2 zones and click on next button. When second page is in view, click on the Zone 3 Plains in the top right. Notice that page crashes.
Screencast: https://app.screencast.com/WdAkVAuXygo3C

> No.of. spark count is incorrect and it's not getting updated when switching between the zones. i.e, by default 3 zones are displayed with 3 spark count. Place all the three sparks in the model and then change the zone count to 2 via the first panel setup and notice that for 2 zones, we are still getting 3 sparks and count in the spark is displayed as -1.
Screencast: https://app.screencast.com/xCIJcbYncYrKQ

It also slightly modifies the top Zone Info buttons to make their behavior less confusing with the new terrain setup panel.
