### PR TITLE
Fix graph after number of zones is updated

### DIFF
--- a/src/components/graph.tsx
+++ b/src/components/graph.tsx
@@ -87,6 +87,11 @@ export const Graph = observer(function WrappedComponent() {
     }
   }, [simulation.timeInHours]);
 
+  useEffect(() => {
+    // Reset datasets when the number of zones changes.
+    chartStore.chart.dataSets = [];
+  }, [chartStore.chart, simulation.zonesCount]);
+
   const updateChartData = (zoneIdx: number) => {
     // Burn acres is in thousands to simplify the y-axis
     const burnAcres = Math.ceil(simulation.simulationAreaAcres * simulation.getZoneBurnPercentage(zoneIdx) / 1000);


### PR DESCRIPTION
This PR fixes an issue found by Saravanan:

> When selecting 2 zones via the first panel, graph section is not updated. Zone 3 is still displayed in the graph view.
Screencast: https://app.screencast.com/ySPVJgS4vaWPe


