### PR TITLE
Remove parallelization since there are only 4 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,6 @@ jobs:
           flags: jest
   cypress:
     runs-on: ubuntu-latest
-    strategy:
-      # when one test fails, DO NOT cancel the other
-      # containers, because this will kill Cypress processes
-      # leaving the Dashboard hanging ...
-      # https://github.com/cypress-io/github-action/issues/48
-      fail-fast: false
-      matrix:
-        # run 3 copies of the current job in parallel
-        containers: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -40,8 +31,6 @@ jobs:
           wait-on: 'http://localhost:8080'
           # only record the results to dashboard.cypress.io if CYPRESS_RECORD_KEY is set
           record: ${{ !!secrets.CYPRESS_RECORD_KEY }}
-          # only do parallel if we have a record key
-          parallel: ${{ !!secrets.CYPRESS_RECORD_KEY }}
         env:
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}


### PR DESCRIPTION
The wildfire cypress tests were failing after a recent upgrade to Cypress 13 because there are just 4 spec files and forcing them to run in 3 parallel threads was causing all 4 tests to run in all 3 threads and then eventually 2 of those threads would fail. I'm removing parallleized tests for this project for now (atleast until we have more tests).