### PR TITLE
feat: rename "Terrain Setup" UI label to "Setup" [WM-3]

### DIFF
--- a/cypress/e2e/smoke.cy.ts
+++ b/cypress/e2e/smoke.cy.ts
@@ -14,7 +14,7 @@ context("Wildfire Smoke Test", () => {
   });
 
   describe("Terrain setup - Adjusting Variables", () => {
-    const headerText = "Terrain Setup";
+    const headerText = "Setup";
     const instructionText1 = "Adjust variables in each zone";
     const zoneTotal = 3;
 

--- a/cypress/e2e/terrairn-setup.cy.ts
+++ b/cypress/e2e/terrairn-setup.cy.ts
@@ -17,7 +17,7 @@ context("Test First Page In Terrain Setup", () => {
     it("Create 3 zone setup using first page display", () => {
       bottomBar.getTerrainSetupButton().click();
       terrain.getTerrainSetupComponent().should("be.visible");
-      terrain.getTerrainHeader().should("be.visible").and("contain", "Terrain Setup");
+      terrain.getTerrainHeader().should("be.visible").and("contain", "Setup");
       terrain.getStepIcon().should("exist").and("contain", "1");
       terrain.getInstructions().should("exist").and("contain", "Select the number of zones in your model");
       terrain.getThreeZoneSetup("exist");
@@ -42,7 +42,7 @@ context("Test First Page In Terrain Setup", () => {
     it("Create 2 zone setup using first page display", () => {
       bottomBar.getTerrainSetupButton().click();
       terrain.getTerrainSetupComponent().should("be.visible");
-      terrain.getTerrainHeader().should("be.visible").and("contain", "Terrain Setup");
+      terrain.getTerrainHeader().should("be.visible").and("contain", "Setup");
       terrain.getRadioButton(1).click();
       terrain.verifyRadioButtonChecked(1);
       terrain.verifyRadioButtonUnchecked(0);

--- a/specs/WM-3-change-terrain-setup-to-just-setup.md
+++ b/specs/WM-3-change-terrain-setup-to-just-setup.md
@@ -1,0 +1,76 @@
+# Rename "Terrain Setup" UI Label to "Setup"
+
+**Jira**: https://concord-consortium.atlassian.net/browse/WM-3
+
+**Status**: **Closed**
+
+## Overview
+
+Rename the user-facing "Terrain Setup" label to "Setup" everywhere it appears in the UI —
+the bottom-bar button, the setup wizard's header, and one sentence in the About dialog — and
+resize the bottom-bar button to the Zeplin design (82px wide with a 62px icon). This aligns
+the app with how the Hazbot behavior-based help overlays (epic AP-80) refer to this control,
+so the help text matches what students see.
+
+## Requirements
+
+- The bottom-bar button caption changes from "Terrain Setup" to "Setup"
+  ([bottom-bar.tsx:106](../src/components/bottom-bar.tsx#L106)).
+- The setup wizard header text changes from "Terrain Setup" to "Setup"
+  ([terrain-panel.tsx:196](../src/components/terrain-panel.tsx#L196)). The wizard has a single
+  persistent header across all three steps, so this one element is "all instances".
+- The About-dialog prose changes from "Use the Terrain Setup window to set..." to "Use the
+  Setup window to set..." ([about-dialog-content.tsx:13](../src/components/top-bar/about-dialog-content.tsx#L13)).
+- The bottom-bar Setup button is resized from its hardcoded `width: 100px` to the **82px**
+  specified by the WM-3 Zeplin design
+  ([bottom-bar.scss:100-103](../src/components/bottom-bar.scss#L100-L103)).
+- A terrain-button-scoped rule is added to [bottom-bar.scss](../src/components/bottom-bar.scss)
+  constraining the button's icon SVG to the design's **62px** width, centered with 10px
+  padding on each side, so the icon is no longer stretched to the full button width. The
+  override is scoped to the Setup button and does not touch the shared `icon-button.scss` —
+  the Spark / Fire Line / Helitack buttons are unaffected.
+- No behavior, icon-artwork, `data-testid`, or `data-name` changes — visible text plus the
+  button-width / icon-sizing CSS adjustments only.
+- Cypress assertions on the literal "Terrain Setup" text are updated so the suite still passes:
+  - [smoke.cy.ts:17](../cypress/e2e/smoke.cy.ts#L17) — `headerText` constant.
+  - [terrairn-setup.cy.ts:20](../cypress/e2e/terrairn-setup.cy.ts#L20) and
+    [terrairn-setup.cy.ts:45](../cypress/e2e/terrairn-setup.cy.ts#L45) — `.contain("Terrain Setup")` assertions.
+
+## Technical Notes
+
+- **Styling changes are confined to the bottom-bar Setup button.** The wizard header and the
+  About-dialog prose absorb the shorter string with no layout change. The bottom-bar button
+  changes are: `.terrainButton` width `100px → 82px`, plus a terrain-scoped rule pinning the
+  icon SVG to 62px centered (10px padding each side). Both live in `bottom-bar.scss`; the
+  shared `icon-button.scss` is left untouched.
+- **Test IDs are stable.** `data-testid="terrain-button"` and `data-testid="terrain-header"`
+  do not contain the visible text and are unaffected.
+- **SVG asset metadata is separate.** The bottom-bar icon SVGs
+  ([src/assets/bottom-bar/terrain-setup.svg](../src/assets/bottom-bar/terrain-setup.svg),
+  `terrain-three.svg`, etc.) contain `<title>` and `data-name="Terrain Setup"` /
+  `data-name="3-zone Terrain Setup"` attributes. Cypress tests
+  ([terrairn-setup.cy.ts](../cypress/e2e/terrairn-setup.cy.ts),
+  [TerrainSetup.js](../cypress/support/elements/TerrainSetup.js)) select zone-count thumbnails
+  via those `data-name` values. These are not the user-visible button caption — leaving the
+  SVGs untouched keeps those selectors working.
+- **Code comments** in [config.ts](../src/config.ts) (lines 20, 68, 70, 118) say "Terrain
+  Setup dialog". Comments only; left unchanged.
+- Jest component tests ([terrain-panel.test.tsx](../src/components/terrain-panel.test.tsx),
+  [bottom-bar.test.tsx](../src/components/bottom-bar.test.tsx)) reference the controls by
+  `data-testid`, not by text, so they need no changes.
+- **Design reference (Zeplin).** The WM-3 design — Zeplin screen "Hazbot Coach Mark Wildfire
+  Overlay" (project `5fe47ae231d1f6a428c53450`, screen `69b2baa489a2e2f3308238b8`) — specifies
+  the "Setup Control": overall control **82 × 74**, white fill, 9px corner radius; the "2-Zone
+  Setup ICON" at **62 × 44** inset 10px from the left and 5px from the top (10px padding on
+  each side within the 82px control); and the "Setup" caption in **Lato Bold 14px, color
+  `#434343`, centered**. Two reference screenshots are also attached to WM-3
+  (`image-20260506-043328.png`, `image-20260506-043347.png`).
+
+## Out of Scope
+
+- Renaming SVG asset files or editing their internal `<title>`/`data-name` metadata, and
+  updating the `config.ts` code comments (non-visible references left unchanged).
+- Changing `data-testid` / `dataTest` identifiers (`terrain-button`, `terrain-header`).
+- Any change to wizard behavior, step flow, layout, or styling (only the bottom-bar Setup
+  button is restyled).
+- The Hazbot/help-overlay content itself (separate epic AP-80 work).

--- a/src/components/bottom-bar.scss
+++ b/src/components/bottom-bar.scss
@@ -98,8 +98,17 @@ $overflowHeight: 11px;
   }
 
   .terrainButton{
-    width: 100px;
+    width: 82px;
     text-align: center;
+
+    // Constrain the Setup icon to its 62px design size (centered, 10px padding each side),
+    // overriding the shared `.iconButton svg { width: 100% }` rule. The extra `button`
+    // element keeps this selector more specific than that shared rule regardless of
+    // stylesheet order. Targets both the icon and its hover-highlight SVG.
+    button svg {
+      width: 62px;
+      left: 10px;
+    }
   }
 
   .fullscreenIcon {

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -103,7 +103,7 @@ export class BottomBar extends BaseComponent<IProps, IState> {
               icon={simulation.zonesCount < 3 ? <TerrainIcon /> : <TerrainThreeIcon />}
               highlightIcon={simulation.zonesCount < 3 ? <TerrainHighlightIcon /> : <TerrainThreeHighlightIcon />}
               disabled={uiDisabled}
-              buttonText="Terrain Setup"
+              buttonText="Setup"
               dataTest="terrain-button"
               onClick={this.handleTerrain}
             />

--- a/src/components/terrain-panel.tsx
+++ b/src/components/terrain-panel.tsx
@@ -193,7 +193,7 @@ export const TerrainPanel: React.FC<IProps> = observer(function WrappedComponent
         ui.showTerrainUI &&
         <div className={`${css.background} ${cssClasses[selectedZone]} ${panelClasses[currentPanel]}`}>
           <div className={css.closeButton} onClick={handleClose}>X</div>
-          <div className={css.header} data-testid="terrain-header">Terrain Setup</div>
+          <div className={css.header} data-testid="terrain-header">Setup</div>
           <div className={css.instructions}>
             <span className={css.setupStepIcon}>{firstPanel === 0 ? currentPanel + 1 : currentPanel}</span>
             { panelInstructions[currentPanel] }

--- a/src/components/top-bar/about-dialog-content.tsx
+++ b/src/components/top-bar/about-dialog-content.tsx
@@ -10,7 +10,7 @@ export const AboutDialogContent = () => (
       model over time.
     </p>
     <p>
-      Use the Terrain Setup window to set the environmental conditions of the simulation including the vegetation type,
+      Use the Setup window to set the environmental conditions of the simulation including the vegetation type,
       drought level, wind speed, and wind direction.
     </p>
     <p>Add sparks to the model, click the play button, and watch the wildfire spread.</p>


### PR DESCRIPTION
Rename the terrain-configuration control to "Setup" in the bottom-bar button, the setup wizard header, and the About-dialog text, so the label matches the Hazbot help overlays (epic AP-80).

- Resize the bottom-bar button to the Zeplin spec (width 100px -> 82px) and add a terrain-scoped rule pinning its icon to 62px, centered, so the icon is no longer stretched to the full button width.
- Update Cypress assertions that checked the old "Terrain Setup" header text.

---

Demo url: https://wildfire.concord.org/branch/rename-terrain-setup/