### PR TITLE
feat: update About modal license to CC BY-NC 4.0 [WM-21]

### DIFF
--- a/src/components/top-bar/copyright.tsx
+++ b/src/components/top-bar/copyright.tsx
@@ -2,16 +2,9 @@ import * as React from "react";
 
 export const Copyright = () => (
   <p style={{ fontSize: "0.8em" }}>
-    <b>Copyright © {(new Date()).getFullYear()}</b> <a href="http://concord.org" target="_blank" rel="noreferrer">The Concord
-    Consortium
-                                                    </a>.
-    All rights reserved. The software is licensed under
-    the <a href="https://github.com/concord-consortium/wildfire-model/blob/master/LICENSE"
-            target="_blank" rel="noreferrer">MIT
-        </a> license.
-    The content is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noreferrer">
-    Creative Commons Attribution 4.0 International License
-                                    </a>.
-    Please provide attribution to the Concord Consortium and the URL <a href="http://concord.org" rel="noreferrer" target="_blank">http://concord.org</a>.
+    <b>Copyright © {(new Date()).getFullYear()}</b> The Concord Consortium.
+    All rights reserved. This resource is licensed under a <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noreferrer">Creative Commons Attribution-NonCommercial 4.0 International License (CC BY-NC 4.0)</a>.
+    Please provide attribution to the Concord Consortium and the URL <a href="https://concord.org" target="_blank" rel="noreferrer">https://concord.org</a>.
+    For full licensing details, see <a href="https://concord.org/licensing/" target="_blank" rel="noreferrer">concord.org/licensing</a>.
   </p>
 );


### PR DESCRIPTION
Replace the Copyright component's content-license text with the standardized CC BY-NC 4.0 wording from the parent epic (DEV-160). Drops the MIT software-license mention per the standardized text, updates the CC license URL, switches concord.org links to https, and adds a link to concord.org/licensing for full details.

The Copyright component is shared by both the About and Share dialogs, so both pick up the new text.

---

Deployed branch: https://wildfire.concord.org/branch/update-about-modal/