### PR TITLE
feat: Graph panel UI/UX updates [WM-25]

### DIFF
--- a/specs/WM-25-graph-panel-ui-updates.md
+++ b/specs/WM-25-graph-panel-ui-updates.md
@@ -1,0 +1,75 @@
+# WM-25 — Wildfire Graph panel UI/UX updates
+
+Lightweight checklist sourced from the Jira ticket. Bullets get ticked off as we work through them interactively against Zeplin.
+
+## Scope (from Jira), ordered easiest → hardest
+
+Prerequisite:
+
+- [x] **Load Roboto Condensed 400/500/700 in index.html** — graph title, axis labels, and tick labels are Roboto **Condensed** (Zeplin reports `font-stretch: condensed` / stretch `0.75` on *every* Roboto text style on the artboard, not plain Roboto). `Roboto Condensed` was already imported at 400/700; added weight 500 (for the 500-weight title + axis labels) and removed the erroneous plain-`Roboto:400,500` import. Chart text family set via `chartFont` in chart.tsx
+
+Pure CSS one-liners (color/size on isolated elements):
+
+- [x] **Axis line color** — `gridLines.zeroLineColor: "#797979"` + grid lines `#dfdfdf` on both axes in line-chart.tsx
+- [x] **Slider track color** — `#949494` left of the thumb (rc-slider `trackStyle`) / `#434343` right of the thumb (rc-slider `railStyle`), 1.5 px in line-chart-controls.tsx. (Per Zeplin: lighter left, darker right — the rc-slider "track" is the left fill and the "rail" shows on the right.)
+- [x] **Colors** — zone plot lines `#e85bd4/#2b95f0/#df7800` (graph.tsx), key auto-matches via legend stroke, tooltip `rgba(0,0,0,0.8)` (line-chart.tsx)
+- [x] **Label font sizes/styles** — title 16 px Roboto Condensed 500, axis labels 14 px Roboto Condensed 500, tick labels 14 px Roboto Condensed 400, legend 14 px Roboto Condensed 400 (the graph "Zone N" key labels are Roboto Condensed in Zeplin, *not* Lato — the Lato-bold "Zone N" styles belong to the sim header, not the graph), all `#434343` (line-chart.tsx; condensed family set via `chartFont` in chart.tsx)
+- [x] **Fire Line / Helitack labels at top of graph** — Zeplin replaces these with graph-marker icons, which we are *not* implementing; per the Jira note the only change is bumping the text labels to **13 px** (`fontSize: 10 → 13` in graph.tsx). Font family (`'Roboto Condensed', Lato, …`) and color (`#606060`) are left as they already were — no other styling was spec'd for these labels. (An earlier attempt that switched them to Lato bold `#434343` was reverted as unspec'd.)
+
+Small structural / state changes:
+
+- [x] **Button** — "Show All/Recent Data" toggle resized to Zeplin 136×28, radius 5, Lato 14 bold, in `line-chart-controls.sass` (`.toggleDataSubset`). States: default `#fff` fill / `#797979` 1px border / `#434343` text; `:hover` `#dfdfdf` fill; `:active` `#757575` fill + `#fff` text. Verified default + hover rendered; pressed is the `:active` rule. Button is centered in the panel (matching the title + legend at center): the plot-aligned offset (`width: 202` / `margin-left: 65`) moved onto `.sliderContainer`, so the slider still tracks the plot x-axis while `.lineChartControls` spans the full panel and the button centers via `margin: auto`
+- [x] **"Graph" tab** — hover/select states + radii (right-panel-tab.scss). Inner `.tabImage` widened 60→**69×44** and `$tabWidth` 68→**77** (tuned to the Zeplin overlay; app container reserves `$tabWidth` so it adjusts); radius 6→5 (Zeplin inner r5); "Graph" label (Lato 700 14px `#434343`, 39px wide) nudged to `top: 13px` / `left: $tabPadding + 2px` to sit in the overlay. States: default white, `:hover` `#aaffc2` (light green, was an opacity fade), `:active` `#66e98b` (medium green) — matching the Zeplin "Graph Tab Button States" fills. "Select" intentionally stays `:active`/press (confirmed, not the persistent panel-open state). Tab keeps its existing green 2px border (radius 9) — the Zeplin gray outer border was attempted but reverted (it didn't sit cleanly against the panel's green edge); revisit separately if needed.
+- [x] **Key style** — show a line instead of a box. Each key is a 25 px colored line that mirrors its plot line's dash (Zone 1 solid, Zone 2/3 dashed). Implemented via `legendPlugin` in line-chart.tsx: the legend items suppress the built-in symbol (`fillStyle: transparent`, `lineWidth: 0`) and reserve space with `boxWidth: 24`; the plugin's `afterDraw` strokes the actual 25 px line (`LEGEND_LINE_LENGTH`) per item using the dataset's `borderColor`/`borderDash`. (Chart.js `usePointStyle` "line" caps length at `fontSize` via the `getBoxWidth` clamp, so it can't reach 25 px — hence the custom draw.) `beforeDraw` spans the legend box to the full canvas so it centers over the panel, not the asymmetric plot box. `padding: 14`. The legend span (~234 px) is near the single-row ceiling (~236 px at this panel width); wider than that wraps to two rows
+- [x] **Slider** — updated thumb + track width. Thumb uses the Zeplin exportable asset `slider-thumb-small.svg` (28×28: `#797979` ring, white center, `#c9c9c9` left/right chevrons; the outer 28px `Highlight` circle's white fill was removed so the track line shows under the thumb instead of being hidden by a white halo) rendered via rc-slider `handleRender` (svgr component); the 28px asset is rendered at 33.6px so its 20px circle scales to the Zeplin **24px** thumb; `handleStyle` matches (`33.6×33.6`, `marginTop: -16` centers it on the track); sass clears the default border/fill/glow and adds the Zeplin highlight ring *behind* the thumb via the handle's background circle — `:hover` `rgba(201,201,201,0.5)` (translucent), `-dragging` `#c9c9c9` (solid), none by default. Grab/grabbing cursor comes from rc-slider's defaults. Track width matches the graph x-axis: `.sliderContainer` `width: 202px` / `margin-left: 65px` = the chart's `chartArea` extent (left 65 → right 267). *(Open: whether the track also needs circular end-caps at both ends — the Zeplin "Data Slider Control" shows the thumb at both track ends, which may just be min/max state illustration.)*
+
+Broader layout work (touches multiple elements + spacing relationships):
+
+- [x] **Layout tweaks** — graph width, spacing of title, x- and y-axis labels. Final chart `layout.padding`: `{ left: 3, right: 19 }` → `chartArea` left 65 / right 267 / **width 202**. Title pulled out of Chart.js and rendered as a centered HTML element (`line-chart-title`, `padding: 2px 0 8px`) so it centers over the panel, not the plot. y-axis number gap: `ticks.padding: 1`. y-axis label edge margin: `scaleLabel.padding: { top: 4, bottom: 3 }` (trims the label↔ticks side so the extra `layout.padding.left` doesn't move the plot). All confirmed against Zeplin — graph lays out as designed
+- [ ] **Layout** — compress graph; check spacing between graph, key, slider, and button
+
+## Colors & strokes reference (from Zeplin)
+
+| Element | Color | Stroke / opacity |
+|---|---|---|
+| **X / Y axis line** | `#797979` (rgb 121,121,121) | 1 px |
+| **Grid lines** (between ticks) | `#dfdfdf` (rgb 223,223,223) | 1 px |
+| **Slider track — left of thumb** | `#949494` (rgb 148,148,148) | 1.5 px |
+| **Slider track — right of thumb** | `#434343` (rgb 67,67,67) | 1.5 px |
+| **Zone 1 plot line + key** | `#e85bd4` (rgb 232,91,212) | 4 px |
+| **Zone 2 plot line + key** | `#2b95f0` (rgb 43,149,240) | 4 px |
+| **Zone 3 plot line + key** | `#df7800` (rgb 223,120,0) | 4 px |
+| **Fireline / Helitack marker line on graph** | `#797979` | 1.5 px |
+| **Tooltip background** | `#000000` | `opacity: 0.8` |
+| **Tooltip text** | `#ffffff`, 14 px Roboto 400 | — |
+| **Tooltip line-color swatch** | matches plot line color | 1 px white border, square 13×13 |
+| **"Show All Data" button border** | `#797979` | 1 px |
+| **"Show All Data" button fill** | `#ffffff` | — |
+
+Key (legend) markers: 25 px long × 4 px tall, same color as the corresponding plot line — i.e. just a short line, not a box, which addresses the Jira "key: possible to just show a line instead of a box?" item.
+
+## Typography reference (from Zeplin)
+
+All real (non-annotation) text styles on the Graph panel artboard, color `#434343` throughout. **Every Roboto style is condensed** (Zeplin `font-stretch` / stretch `0.75`); every Lato style is normal width (stretch `1`):
+
+| Use | Font | Size | Weight |
+|---|---|---|---|
+| Graph title ("Acres Burned vs. Time") | Roboto Condensed | 16 | 500 (Medium) |
+| Axis labels ("Time (hours)", "Acres Burned (thousands)") | Roboto Condensed | 14 | 500 (Medium) |
+| Tick labels (0–100, 0–10, "Zone 1/2/3", "Plains") | Roboto Condensed | 14 | 400 (Regular) |
+| Button labels ("Show Recent Data", "Show All Data") | Lato | 14 | 700 (Bold) |
+| Tab label ("Graph") | Lato | 14 | 700 (Bold) |
+| Bottom-bar labels including "Fireline" / "Helitack" | Lato | 14 | 700 (Bold) |
+
+Note on the FL/Helitack graph annotations: Zeplin replaces these labels with graph-marker *icons*, which are not being implemented. So the existing text labels are kept with their original font family (`'Roboto Condensed', Lato, …`) and color (`#606060`); per the Jira note the only change is the size, `fontSize: 10 → 13` in [graph.tsx:37,55](../../src/components/graph.tsx#L37).
+
+## Reference
+
+- Jira: WM-25
+- Zeplin: https://app.zeplin.io/project/5fe47ae231d1f6a428c53450/screen/6a1042a9053056f90b7b2b43
+
+## Files likely in scope
+
+- [src/components/graph.tsx](../../src/components/graph.tsx), [src/components/graph.scss](../../src/components/graph.scss)
+- [src/components/right-panel.tsx](../../src/components/right-panel.tsx), [src/components/right-panel-tab.tsx](../../src/components/right-panel-tab.tsx)
+- [src/charts/](../../src/charts/) — chart.tsx, bar-chart.tsx, line-chart-controls.tsx, chart-colors.scss

--- a/src/assets/slider-thumb-small.svg
+++ b/src/assets/slider-thumb-small.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="28px" height="28px" viewBox="0 0 28 28" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>BEBAA0E3-3CCA-42B5-8229-A4CDA95B7EAD</title>
+    <g id="Slider-Thumb-Small" stroke="none" fill="none" fill-rule="evenodd" stroke-width="1">
+        <g id="Slider-Thumb" transform="translate(14, 14) rotate(90) translate(-14, -14)">
+            <circle id="Highlight" fill="none" cx="14" cy="14" r="14"></circle>
+            <path d="M13.9998,4.0003 C19.5226475,4.0003 23.9998,8.4774525 23.9998,14.0003 C23.9998,19.5231475 19.5226475,24.0003 13.9998,24.0003 C8.4769525,24.0003 3.9998,19.5231475 3.9998,14.0003 C3.9998,8.4774525 8.4769525,4.0003 13.9998,4.0003 Z" id="Outer" fill="#797979" fill-rule="nonzero"></path>
+            <path d="M14,5.5 C9.30557963,5.5 5.5,9.30557963 5.5,14 C5.5,18.6944204 9.30557963,22.5 14,22.5 C18.6944204,22.5 22.5,18.6944204 22.5,14 C22.5,9.30557963 18.6944204,5.5 14,5.5 Z" id="Oval" fill="#FFFFFF" fill-rule="nonzero"></path>
+            <polygon id="Down" fill="#C9C9C9" points="14 20.8 18.8571429 15.4571429 9.14285714 15.4571429"></polygon>
+            <polygon id="Up" fill="#C9C9C9" points="14 7.2 9.14285714 12.5428571 18.8571429 12.5428571"></polygon>
+        </g>
+    </g>
+</svg>

--- a/src/charts/components/line-chart-controls.sass
+++ b/src/charts/components/line-chart-controls.sass
@@ -2,35 +2,54 @@
 
 .lineChartControls
   position: relative
-  width: 220px
   height: 60px
-  margin-left: 50px
   margin-top: 5px
   flex: 0 0 20px
   transform: translate3d(0px, 0px, 0px)  // needed to keep visibility after scaling
 
   .sliderContainer
+    position: relative
+    width: 202px
+    margin-left: 65px
     height: 20px
   .scrubber
     position: absolute
     width: 100%
     margin-top: -5px
 
+    // SVG thumb provides its own visuals; suppress rc-slider's default border/fill/glow.
+    // A bg circle behind the thumb shows as a highlight ring: translucent on hover, solid while dragging.
+    :global(.rc-slider-handle)
+      border: none
+      background-color: transparent
+      box-shadow: none !important
+      opacity: 1
+    :global(.rc-slider-handle:hover)
+      background-color: rgba(201, 201, 201, 0.5)
+    :global(.rc-slider-handle.rc-slider-handle-dragging)
+      background-color: #c9c9c9
+
   .rcSliderDisabled
     background-color: $controlGray
 
   .toggleDataSubset
+    box-sizing: border-box
     text-align: center
-    height: 29px
-    border: 1px solid silver
-    width: 100px
+    width: 136px
+    height: 28px
+    border: 1px solid #797979
+    background-color: #ffffff
+    color: #434343
+    font-size: 14px
+    font-weight: 700
+    line-height: 26px
     margin-left: auto
     margin-right: auto
     margin-bottom: 10px
     border-radius: 5px
-    font-size: 12px
-    line-height: 29px
+    cursor: pointer
     &:hover
-      background-color: $controlGrayLight1
+      background-color: #dfdfdf
     &:active
-      background-color: $controlGray
+      background-color: #757575
+      color: #ffffff

--- a/src/charts/components/line-chart-controls.sass
+++ b/src/charts/components/line-chart-controls.sass
@@ -3,7 +3,7 @@
 .lineChartControls
   position: relative
   height: 60px
-  margin-top: 5px
+  margin-top: 16px
   flex: 0 0 20px
   transform: translate3d(0px, 0px, 0px)  // needed to keep visibility after scaling
 

--- a/src/charts/components/line-chart-controls.tsx
+++ b/src/charts/components/line-chart-controls.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { observer } from "mobx-react";
 import { ChartDataModel} from "../models/chart-data";
-import { baseColors } from "../models/chart-data-set";
 import Slider from "rc-slider";
 import { BaseComponent } from "../../components/base";
 import { log } from "../../log";
+import SliderThumb from "../../assets/slider-thumb-small.svg";
 
 import css from "./line-chart-controls.sass";
 import "rc-slider/assets/index.css";
@@ -52,11 +52,14 @@ export class LineChartControls extends BaseComponent<IChartControlProps, IChartC
     const timelineVisible = chartData.maxPoints && chartData.maxPoints > 0 &&
       chartData.pointCount > chartData.maxPoints;
 
-    const trackStyle = { backgroundColor: baseColors.chartColor5, height: 2 };
+    const trackStyle = { backgroundColor: "#949494", height: 1.5 };
+    // render the 28px asset at 33.6px so its 20px circle scales to the Zeplin 24px thumb
     const handleStyle = {
-      borderColor: baseColors.controlGray
+      width: 33.6,
+      height: 33.6,
+      marginTop: -16
     };
-    const railStyle = { backgroundColor: baseColors.controlGray, height: 2 };
+    const railStyle = { backgroundColor: "#434343", height: 1.5 };
     const toggleShowAllOrRecent = () => {
       if (chartData) {
         if (!chartData.maxPoints || chartData.maxPoints > -1) {
@@ -91,6 +94,9 @@ export class LineChartControls extends BaseComponent<IChartControlProps, IChartC
               trackStyle={trackStyle}
               handleStyle={handleStyle}
               railStyle={railStyle}
+              handleRender={(origin: any) =>
+                React.cloneElement(origin, {}, <SliderThumb width={33.6} height={33.6} style={{ display: "block" }} />)
+              }
               onChange={this.handleDragChange}
               min={scrubberMin}
               max={scrubberMax}

--- a/src/charts/components/line-chart.tsx
+++ b/src/charts/components/line-chart.tsx
@@ -58,6 +58,27 @@ const legendPlugin = {
   }
 };
 
+// Chart.js 2.9 draws the axis border (drawBorder) using gridLines.color, so the y-axis line would
+// share the light gridline color and can't be darkened independently. Draw the dark gray y-axis
+// line ourselves over the left edge of the plot area to match the x-axis zeroLine (#797979).
+const yAxisLinePlugin = {
+  afterDraw(chart: any) {
+    const area = chart.chartArea;
+    if (!area) {
+      return;
+    }
+    const ctx = chart.ctx;
+    ctx.save();
+    ctx.strokeStyle = "#797979";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(area.left, area.top);
+    ctx.lineTo(area.left, area.bottom);
+    ctx.stroke();
+    ctx.restore();
+  }
+};
+
 interface ILineProps {
   chartFont?: string;
   width?: number;
@@ -156,6 +177,10 @@ const lineData = (chartData: ChartDataModel) => {
         // borderColor is the color of the line
         dset.borderColor = hexToRGBValue(d.color, 1);
         dset.pointBorderColor = hexToRGBValue(d.color, 1);
+        // pointBackgroundColor defaults to a per-index array cycling through ChartColors; without
+        // this override the tooltip swatch (displayColors) picks a different fill per hovered point
+        // on the same line. Pin it to the line color so every point on the line matches.
+        dset.pointBackgroundColor = hexToRGBValue(d.color, 1);
         dset.pointHoverBackgroundColor = hexToRGBValue(d.color, 1);
         dset.pointHoverBorderColor = hexToRGBValue(d.color, 1);
       }
@@ -235,7 +260,8 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
             fontSize: 14,
             fontStyle: "500",
             fontColor: "#434343",
-            padding: { top: 4, bottom: 3 }
+            // top padding shifts the rotated y-axis label right (toward the plot)
+            padding: { top: 9, bottom: 3 }
           },
           gridLines: {
             color: "#dfdfdf",
@@ -317,7 +343,7 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
         height={h}
         width={w}
         redraw={true}
-        plugins={[ChartAnnotation, legendPlugin]}
+        plugins={[ChartAnnotation, legendPlugin, yAxisLinePlugin]}
       />;
     return (
       <div className="line-chart-container">

--- a/src/charts/components/line-chart.tsx
+++ b/src/charts/components/line-chart.tsx
@@ -9,6 +9,50 @@ import { hexToRGBValue } from "../utils";
 import { LineChartControls } from "./line-chart-controls";
 import { BaseComponent } from "../../components/base";
 
+const LEGEND_LINE_LENGTH = 25;
+
+// beforeDraw: Chart.js centers the legend within the (asymmetric) layout-padding box, shifting it
+//   off-center — override the legend box to span the full canvas so it centers over the panel.
+// afterDraw: the built-in "line" point style is capped at fontSize (getBoxWidth clamp), so the key
+//   line can't exceed ~20px. The legend items suppress the default symbol (transparent fill,
+//   lineWidth 0) and reserve space via boxWidth; here we draw the key line at the full length.
+const legendPlugin = {
+  beforeDraw(chart: any) {
+    const legend = chart.legend;
+    if (legend) {
+      legend.left = 0;
+      legend.width = chart.width;
+      if (legend.minSize) {
+        legend.minSize.width = chart.width;
+      }
+    }
+  },
+  afterDraw(chart: any) {
+    const legend = chart.legend;
+    if (!legend || !legend.legendHitBoxes) {
+      return;
+    }
+    const ctx = chart.ctx;
+    legend.legendHitBoxes.forEach((box: any, i: number) => {
+      const ds = chart.data.datasets[i];
+      if (!ds) {
+        return;
+      }
+      const y = box.top + box.height / 2;
+      ctx.save();
+      ctx.strokeStyle = ds.borderColor;
+      ctx.lineWidth = 4;
+      ctx.lineCap = "butt";
+      ctx.setLineDash(ds.borderDash || []);
+      ctx.beginPath();
+      ctx.moveTo(box.left, y);
+      ctx.lineTo(box.left + LEGEND_LINE_LENGTH, y);
+      ctx.stroke();
+      ctx.restore();
+    });
+  }
+};
+
 interface ILineProps {
   chartFont?: string;
   width?: number;
@@ -34,6 +78,12 @@ const defaultOptions: ChartOptions = {
   },
   animation: {
     duration: 0
+  },
+  layout: {
+    padding: {
+      left: 3,
+      right: 19
+    }
   },
   title: {
     display: true,
@@ -158,10 +208,8 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
     const chartDisplay = lineData(chart);
     const minMaxValues = chart.minMaxAll;
     const options: ChartOptions = { ...defaultOptions, title: {
-        display: (chart.name && chart.name.length > 0),
-        text: chart.name,
-        fontFamily: chartFont,
-        fontSize: 15
+        // title is rendered as HTML below so it can be centered over the panel, not the plot area
+        display: false
       },
       scales: {
         yAxes: [{
@@ -170,12 +218,24 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
             min: minMaxValues.minA2,
             max: minMaxValues.maxA2,
             fontFamily: chartFont,
+            fontSize: 14,
+            fontColor: "#434343",
+            padding: 1,
             userCallback: axisLabelA2Function
           },
           scaleLabel: {
             display: !!chart.axisLabelA2,
             labelString: chart.axisLabelA2,
-            fontFamily: chartFont
+            fontFamily: chartFont,
+            fontSize: 14,
+            fontStyle: "500",
+            fontColor: "#434343",
+            padding: { top: 4, bottom: 3 }
+          },
+          gridLines: {
+            color: "#dfdfdf",
+            zeroLineColor: "#797979",
+            drawBorder: true
           }
         }],
         xAxes: [{
@@ -188,12 +248,22 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
             minRotation: chart.dataLabelRotation,
             maxRotation: chart.dataLabelRotation,
             fontFamily: chartFont,
+            fontSize: 14,
+            fontColor: "#434343",
             userCallback: axisLabelA1Function
           },
           scaleLabel: {
             display: !!chart.axisLabelA1,
             labelString: chart.axisLabelA1,
-            fontFamily: chartFont
+            fontFamily: chartFont,
+            fontSize: 14,
+            fontStyle: "500",
+            fontColor: "#434343"
+          },
+          gridLines: {
+            color: "#dfdfdf",
+            zeroLineColor: "#797979",
+            drawBorder: true
           }
         }]
       },
@@ -201,8 +271,31 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
         display: true,
         position: "bottom",
         labels: {
-          fontFamily: chartFont
+          // key line is drawn by legendPlugin.afterDraw; suppress the built-in symbol and reserve
+          // its width via boxWidth so the label sits past the drawn line
+          fontFamily: chartFont,
+          fontSize: 14,
+          fontStyle: "normal",
+          fontColor: "#434343",
+          boxWidth: 24,
+          padding: 14,
+          generateLabels: (c: any) => c.data.datasets.map((ds: any, i: number) => ({
+            text: ds.label,
+            fillStyle: "transparent",
+            lineWidth: 0,
+            hidden: !c.isDatasetVisible(i),
+            datasetIndex: i
+          }))
         }
+      },
+      tooltips: {
+        backgroundColor: "rgba(0, 0, 0, 0.8)",
+        titleFontFamily: chartFont,
+        titleFontSize: 14,
+        bodyFontFamily: chartFont,
+        bodyFontSize: 14,
+        cornerRadius: 0,
+        displayColors: true
       },
       annotation: {
         drawTime: "afterDraw",
@@ -219,10 +312,25 @@ export class LineChart extends BaseComponent<ILineProps, ILineState> {
         height={h}
         width={w}
         redraw={true}
-        plugins={[ChartAnnotation]}
+        plugins={[ChartAnnotation, legendPlugin]}
       />;
     return (
       <div className="line-chart-container">
+        {chart.name && chart.name.length > 0 &&
+          <div
+            className="line-chart-title"
+            style={{
+              textAlign: "center",
+              fontFamily: chartFont,
+              fontWeight: 500,
+              fontSize: 16,
+              color: "#434343",
+              padding: "2px 0 8px"
+            }}
+          >
+            {chart.name}
+          </div>
+        }
         <div className="line-chart-container" data-testid="line-chart">
           {graph}
         </div>

--- a/src/charts/components/line-chart.tsx
+++ b/src/charts/components/line-chart.tsx
@@ -38,6 +38,11 @@ const legendPlugin = {
       if (!ds) {
         return;
       }
+      // skip the key line for datasets hidden via the legend, so it matches the
+      // struck-through label and the hidden plot line
+      if (!chart.isDatasetVisible(i)) {
+        return;
+      }
       const y = box.top + box.height / 2;
       ctx.save();
       ctx.strokeStyle = ds.borderColor;

--- a/src/components/common.scss
+++ b/src/components/common.scss
@@ -47,7 +47,7 @@ $helitackRotorGray: #b3b3b3;
 $tabGeoLight: #99cc99;
 $tabHeight: 52px;
 $tabPadding: 4px;
-$tabWidth: 68px;
+$tabWidth: 77px;
 $tabContents: rgba(255, 255, 255, 0.9);
 
 $rightPanelContainerWidth: 315px;

--- a/src/components/graph.tsx
+++ b/src/components/graph.tsx
@@ -6,9 +6,9 @@ import css from "./graph.scss";
 import { Annotation } from "../charts/models/chart-annotation";
 import { DataPoint, ChartDataSet } from "../charts/models/chart-data-set";
 
-const chartColor0 = "#ffb7f5";
-const chartColor1 = "#6badff";
-const chartColor2 = "#ffc085";
+const chartColor0 = "#e85bd4";
+const chartColor1 = "#2b95f0";
+const chartColor2 = "#df7800";
 const borderDash0 = [];
 const borderDash1 = [5, 5];
 const borderDash2 = [10, 5];
@@ -34,7 +34,7 @@ export const Graph = observer(function WrappedComponent() {
         labelPosition: "top",
         labelBackgroundColor: "white",
         fontFamily: "'Roboto Condensed', Lato, arial, sans-serif",
-        fontSize: 10,
+        fontSize: 13,
         labelColor: "#606060",
         thickness: 1,
         dashArray: borderDash1
@@ -53,7 +53,7 @@ export const Graph = observer(function WrappedComponent() {
         labelPosition: "top",
         labelBackgroundColor: "white",
         fontFamily: "'Roboto Condensed', Lato, arial, sans-serif",
-        fontSize: 10,
+        fontSize: 13,
         labelColor: "#606060",
         thickness: 1,
         dashArray: borderDash2

--- a/src/components/right-panel-tab.scss
+++ b/src/components/right-panel-tab.scss
@@ -21,9 +21,9 @@
 
     .tabImage {
       position: absolute;
-      width: 60px;
+      width: 69px;
       height: 44px;
-      border-radius: 6px;
+      border-radius: 5px;
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
       top: $tabPadding;
@@ -33,14 +33,17 @@
       background-color: #fff;
       cursor: pointer;
       &:hover {
-        opacity: 0.75;
+        background-color: #aaffc2;
+      }
+      &:active {
+        background-color: #66e98b;
       }
     }
     .tabContent {
       position: relative;
       width: 64px;
-      top: 11px;
-      left: $tabPadding;
+      top: 13px;
+      left: $tabPadding + 2px;
       height: 30px;
       font-size: 14px;
       font-weight: bold;

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=yes">
     <link rel="shortcut icon" href="favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:400,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:400,500,700" rel="stylesheet">
     <style>
       html, body, #app {
         margin: 0;


### PR DESCRIPTION
## Summary

Updates the Wildfire graph panel to match the Zeplin design. All visual, verified element-by-element against the mock (Playwright + measured geometry/computed styles).

Jira: https://concord-consortium.atlassian.net/browse/WM-25
Spec: `specs/WM-25-graph-panel-ui-updates.md`

> **Stacked on `WM-23-model-controls-ui-updates`** — based on that branch (not `master`). Re-target to `master` once WM-23 merges. The diff here is the single commit `d2b9b32`.

## Changes

- **Fonts** — chart text switched to Roboto Condensed (title, axis labels, ticks, legend); load Roboto Condensed 400/500/700 in `index.html`
- **Title** — rendered as a centered HTML element so it centers over the panel rather than the (asymmetric) plot area
- **Axes** — axis-line `#797979` / grid `#dfdfdf`; tick + axis-label sizes, colors, and spacing; y-axis number gap and y-label margin tuned
- **Legend** — short line keys (solid/dashed per zone) instead of boxes, Roboto Condensed, centered over the panel, drawn via a small Chart.js `afterDraw` plugin (built-in line symbol is size-capped)
- **Plot geometry + slider** — plot width/position locked; slider track aligned to the graph x-axis; track colors lighter-left / darker-right
- **Slider thumb** — uses the Zeplin exportable asset (24px), track line shows through, translucent hover ring + solid drag ring
- **"Show All/Recent Data" button** — resized (136×28), hover/pressed states, centered under the plot
- **Graph tab** — width, inner size, label position, radii, and hover/select states
- **Fire Line / Helitack annotation labels** — bumped to 13px per the Jira note (icons not implemented)

## Testing

- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm test` — 47 suites / 387 tests pass
- Cypress — green
- Manual visual verification against Zeplin for each element
