### PR TITLE
chore: re-extract hazbot rule-sets from 2026-06-02 workbook

### DIFF
--- a/docs/hazbot-validation/24.md
+++ b/docs/hazbot-validation/24.md
@@ -21,7 +21,7 @@
 
 ### Category 1: Did not run the simulation. A.k.a. Click button (before they do anything else)
 
-- **Feedback**: Hazbot: Hello, again! I will analyze your model after you run it! Scroll up and follow the instructions at the top of the page! [Okay]
+- **Feedback**: Hazbot: Hello, again! I will analyze your model after you run it. Scroll up and follow the instructions at the top of the page! [Okay]
 - **Expression**: `NOT ranSimulation`
 - **Logical breakdown**:
   - NOT:
@@ -50,7 +50,7 @@
 
 ### Category 4: Ran the simulation once with a different wind speed or a direction
 
-- **Feedback**: Hazbot: Keep going! Setup the model with different wind settings to compare!
+- **Feedback**: Hazbot: Keep going! Set up the model with different wind settings to compare! [Show me]
 - **Expression**: `NOT (uniqueWindValuesUsed.size > 1) AND uniqueNonZeroWindValuesUsed.size > 0`
 - **Logical breakdown**:
   - ALL of:

--- a/docs/hazbot-validation/25.md
+++ b/docs/hazbot-validation/25.md
@@ -47,7 +47,7 @@
 
 ### Category 4: Ran the simulation and placed two sparks, but not at the top and bottom of the mountain
 
-- **Feedback**: Hazbot: Make sure to place one spark at the top of a mountain and one at the bottom!
+- **Feedback**: Hazbot: Make sure to place one spark at the bottom of a mountain and one at the top! [Show me]
 - **Expression**: `ranSimulation WITH OneSparkPerZone AND NOT SparksAtTopAndBottom`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:
@@ -58,7 +58,7 @@
 
 ### Category 5: Ran the simulation with one spark at the top and one at the bottom of the mountain but with different zone setups.
 
-- **Feedback**: Hazbot: Looks like the two zones are different. Make sure they have the same vegetation and drought!
+- **Feedback**: Hazbot: Looks like the two zones are different. Make sure they have the same vegetation and drought! [Show me]
 - **Expression**: `ranSimulation WITH OneSparkPerZone AND SparksAtTopAndBottom AND NOT UniformZoneSettings`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:
@@ -71,7 +71,7 @@
 
 ### Category 6: Ran the simulation with one spark at the top and one at the bottom of the mountain with the same zone setups.
 
-- **Feedback**: Hazbot: Great job! You’re ready to answer the questions below.
+- **Feedback**: Hazbot: Great job! You’re ready to answer the questions below. [Hooray!]
 - **Expression**: `ranSimulation WITH OneSparkPerZone AND SparksAtTopAndBottom AND UniformZoneSettings`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:

--- a/docs/hazbot-validation/32.md
+++ b/docs/hazbot-validation/32.md
@@ -52,7 +52,7 @@
 
 ### Category 4: Ran the simulation with 3 different vegetation types assigned (one in each zone) and different drought levels between zones
 
-- **Feedback**: Hazbot: To compare vegetation, make sure the drought level is the same for each zone!
+- **Feedback**: Hazbot: To compare vegetation, make sure the drought level is the same for each zone! [Show me]
 - **Expression**: `ranSimulation WITH UniqueVegetationPerZone AND NOT UniformDroughtLevels`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:
@@ -63,7 +63,7 @@
 
 ### Category 5: Ran the simulation with 3 different vegetations (one in each zone), same drought, but without one spark in each zone)
 
-- **Feedback**: Hazbot: I don’t see any sparks. Add one spark in each zone so you can compare wildfire spread!
+- **Feedback**: Hazbot: I don’t see three sparks. Add one spark in each zone so you can compare wildfire spread! [Show me]
 - **Expression**: `ranSimulation WITH UniqueVegetationPerZone AND NOT OneSparkPerZone`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:
@@ -74,7 +74,7 @@
 
 ### Category 6: Ran the simulation with 3 different vegetations (one in each zone), same drought, and one spark in each zone
 
-- **Feedback**: Hazbot: Great job comparing three types of vegetation! You’re ready to answer the questions below.
+- **Feedback**: Hazbot: Great job comparing three types of vegetation! You’re ready to answer the questions below. [Hooray!]
 - **Expression**: `ranSimulation WITH UniqueVegetationPerZone AND UniformDroughtLevels AND OneSparkPerZone`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:

--- a/docs/hazbot-validation/33.md
+++ b/docs/hazbot-validation/33.md
@@ -45,7 +45,7 @@
 
 ### Category 3: Ran the simulation with other zone setup variables changed but without assigning forest with and without suppression
 
-- **Feedback**: Hazbot: Don't forget to compare the two types of forest. I can help![Show me]
+- **Feedback**: Hazbot: Don't forget to compare the two types of forest. I can help! [Show me]
 - **Expression**: `setAnyVar AND ranSimulation WITH NOT ForestWAWOSuppression`
 - **Logical breakdown**:
   - ALL of:
@@ -56,7 +56,7 @@
 
 ### Category 4: Ran the simulation with zones with forest and forest w/ suppression, and a spark not placed in each zone
 
-- **Feedback**: Hazbot: I do not see a spark in each zone. Let’s put one in each so you can compare wildfire spread.[Show me]
+- **Feedback**: Hazbot: I do not see a spark in each zone. Let’s put one in each so you can compare wildfire spread. [Show me]
 - **Expression**: `ranSimulation WITH ForestWAWOSuppression AND NOT OneSparkPerZone`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:
@@ -67,7 +67,7 @@
 
 ### Category 5: Ran the simulation with zones with forest and forest w/ suppression, a spark placed in each zone, but different drought between the zones
 
-- **Feedback**: Hazbot: To compare forest types, make sure the drought level is the same in each zone![Show me]
+- **Feedback**: Hazbot: To compare forest types, make sure the drought level is the same in each zone! [Show me]
 - **Expression**: `ranSimulation WITH ForestWAWOSuppression AND OneSparkPerZone AND NOT UniformDroughtLevels`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:
@@ -80,7 +80,7 @@
 
 ### Category 6: Ran the simulation with zones with forest and forest w/ suppression, a spark in each zone, and same drought
 
-- **Feedback**: Hazbot: Great job! You’re ready to answer the questions below.[Show me]
+- **Feedback**: Hazbot: Great job! You’re ready to answer the questions below. [Hooray!]
 - **Expression**: `ranSimulation WITH ForestWAWOSuppression AND OneSparkPerZone AND UniformDroughtLevels`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:

--- a/docs/hazbot-validation/34.md
+++ b/docs/hazbot-validation/34.md
@@ -52,7 +52,7 @@
 
 ### Category 4: Ran the simulation two or more times, tested all four vegetation types, and changed drought and winds.
 
-- **Feedback**: Hazbot: Great job! You’re ready to answer the questions below.
+- **Feedback**: Hazbot: Great job! You’re ready to answer the questions below. [Hooray!]
 - **Expression**: `setDroughtLevel AND setWind AND triedAllVegetations`
 - **Logical breakdown**:
   - ALL of:

--- a/docs/hazbot-validation/35.md
+++ b/docs/hazbot-validation/35.md
@@ -29,7 +29,7 @@
 
 ### Category 1: Did not run the simulation
 
-- **Feedback**: Hazbot: You haven’t run the model yet. Run it before answering the questions.
+- **Feedback**: Hazbot: You haven’t run the model yet. Run it before answering the questions. [Okay]
 - **Expression**: `NOT ranSimulation`
 - **Logical breakdown**:
   - NOT:
@@ -37,7 +37,7 @@
 
 ### Category 2: Ran the simulation with default setup values only
 
-- **Feedback**: Hazbot: Click “Setup” and change the conditions to compare forest with and without suppression. Then run the model again.
+- **Feedback**: Hazbot: Click Setup and change the conditions to compare forest with and without suppression. Then run the model again. [Show me]
 - **Expression**: `ranSimulation AND NOT setAnyVar`
 - **Logical breakdown**:
   - ALL of:
@@ -47,16 +47,18 @@
 
 ### Category 3: Ran the simulation with terrain, drought or wind changed but without assigning forest with and without suppression to each zone
 
-- **Feedback**: Hazbot: Let’s focus on forests with and without suppression in the vegetation settings.
-- **Expression**: `ranSimulation WITH NOT ForestWAWOSuppression`
+- **Feedback**: Hazbot: Let’s focus on forests with and without suppression in the vegetation settings. [Show me]
+- **Expression**: `setAnyVar AND ranSimulation WITH NOT ForestWAWOSuppression`
 - **Logical breakdown**:
-  - exists a `ranSimulation` reading where:
-    - NOT:
-      - sim-prop `ForestWAWOSuppression` is true
+  - ALL of:
+    - `setAnyVar` is true
+    - exists a `ranSimulation` reading where:
+      - NOT:
+        - sim-prop `ForestWAWOSuppression` is true
 
 ### Category 4: Ran the simulation with forest and forest with suppression assigned but with different drought levels between the zones
 
-- **Feedback**: Hazbot: To compare forest types, make sure the both zones have the same drought level!
+- **Feedback**: Hazbot: To compare forest types, make sure the both zones have the same drought level! [Show me]
 - **Expression**: `ranSimulation WITH ForestWAWOSuppression AND NOT UniformDroughtLevels`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:
@@ -67,7 +69,7 @@
 
 ### Category 5: Ran the simulation with forest with and without suppression assigned but different terrains between the zones
 
-- **Feedback**: Hazbot: To compare forest types, make sure both zones have mountains.
+- **Feedback**: Hazbot: To compare forest types, make sure both zones have mountains. [Show me]
 - **Expression**: `ranSimulation WITH ForestWAWOSuppression AND NOT UniformTerrainTypes`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:
@@ -78,7 +80,7 @@
 
 ### Category 6: Ran the simulation with forest with and without suppression, same drought and terrain types between zones, but without a spark in each zone
 
-- **Feedback**: Hazbot: I don’t see a spark in both zones. Add one spark to each so you can compare wildfire spread.
+- **Feedback**: Hazbot: I don’t see a spark in both zones. Add one spark to each so you can compare wildfire spread. [Show me]
 - **Expression**: `ranSimulation WITH ForestWAWOSuppression AND UniformTerrainTypes AND UniformDroughtLevels AND NOT OneSparkPerZone`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:
@@ -93,7 +95,7 @@
 
 ### Category 7: Ran the simulation with forest with and without suppression, same drought and terrain between zones, and a spark in each zone
 
-- **Feedback**: Hazbot: Great job! You’re ready to answer the questions below.
+- **Feedback**: Hazbot: Great job! You’re ready to answer the questions below. [Hooray!]
 - **Expression**: `ranSimulation WITH ForestWAWOSuppression AND UniformTerrainTypes AND UniformDroughtLevels AND OneSparkPerZone`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:

--- a/docs/hazbot-validation/42.md
+++ b/docs/hazbot-validation/42.md
@@ -28,14 +28,14 @@
 
 ### Category 2: Ran the simulation with a changed vegetation type, drought, or wind.
 
-- **Feedback**: Hazbot: Let’s run the model using the original settings!
+- **Feedback**: Hazbot: Let’s run the model using the original settings! [Show me]
 - **Expression**: `setAnyVar`
 - **Logical breakdown**:
   - `setAnyVar` is true
 
 ### Category 3: Ran the simulation without changed variables.
 
-- **Feedback**: Hazbot: Great job! You’re ready to answer the questions below.
+- **Feedback**: Hazbot: Great job! You’re ready to answer the questions below. [Hooray!]
 - **Expression**: `ranSimulation AND NOT setAnyVar`
 - **Logical breakdown**:
   - ALL of:

--- a/docs/hazbot-validation/45.md
+++ b/docs/hazbot-validation/45.md
@@ -39,7 +39,7 @@
 
 ### Category 3: Ran the model with no setup changes and with no fireline and helitacks OR With firelines only OR with helitacks only in a single or multiple trials.
 
-- **Feedback**: Hazbot: Try using both the firelines and helitacks!
+- **Feedback**: Hazbot: Try using both the firelines and helitacks! [Show me]
 - **Expression**: `NOT (usedFireline AND usedHelitack) AND ranSimulation WITH DefaultVars`
 - **Logical breakdown**:
   - ALL of:
@@ -52,7 +52,7 @@
 
 ### Category 4: Ran the model with no setup changes and with both firelines and helitacks used in a single or multiple trials.
 
-- **Feedback**: Hazbot: Great job! You’re ready to answer the questions below.
+- **Feedback**: Hazbot: Great job! You’re ready to answer the questions below. [Hooray!]
 - **Expression**: `ranSimulation WITH DefaultVars AND Fireline AND ranSimulation WITH DefaultVars AND Helitack`
 - **Logical breakdown**:
   - ALL of:

--- a/docs/hazbot-validation/47.md
+++ b/docs/hazbot-validation/47.md
@@ -48,7 +48,7 @@
 
 ### Category 4: Ran with original settings and with at least one fireline or helitack, but without first running with original settings with neither fireline nor helitack
 
-- **Feedback**: Hazbot: Did you try running the model without firelines and helitacks to see where the fire spread?
+- **Feedback**: Hazbot: Did you try running the model without firelines and helitacks to see where the fire spread? [Show me]
 - **Expression**: `NOT ranSimulation WITH DefaultVars AND NOT (Fireline OR Helitack) AND ranSimulation WITH DefaultVars AND (Fireline OR Helitack)`
 - **Logical breakdown**:
   - ALL of:
@@ -69,7 +69,7 @@
 
 ### Category 5: Ran with original settings and with at least one fireline or helitack, after (or before) running with original settings with neither fireline nor helitack
 
-- **Feedback**: Hazbot: Great job on this investigation! Keep working through the activity!
+- **Feedback**: Hazbot: Great job on this investigation! Keep working through the activity! [Hooray!]
 - **Expression**: `ranSimulation WITH DefaultVars AND NOT (Fireline OR Helitack) AND ranSimulation WITH DefaultVars AND (Fireline OR Helitack)`
 - **Logical breakdown**:
   - ALL of:

--- a/docs/hazbot-validation/54.md
+++ b/docs/hazbot-validation/54.md
@@ -55,7 +55,7 @@
 
 ### Category 4: Ran with original vegetation setting and severe drought across all three zones and with at least one fireline or helitack in one or more trials
 
-- **Feedback**: Hazbot: Great job on this investigation! Keep working through the activity!
+- **Feedback**: Hazbot: Great job on this investigation! Keep working through the activity! [Hooray!]
 - **Expression**: `ranSimulation WITH DefaultVegetations AND SevereDroughts AND (Fireline OR Helitack)`
 - **Logical breakdown**:
   - exists a `ranSimulation` reading where:

--- a/docs/hazbot-validation/localhost-urls.md
+++ b/docs/hazbot-validation/localhost-urls.md
@@ -16,7 +16,7 @@ These rulesets have defined categories/expressions in [src/hazbot/rule-sets/](..
 |-----|----------|------|--------|----------------|----------|
 | 23 | 2 | 3 | plainsTwoZone | [23.md](23.md) | http://localhost:8080/?preset=plainsTwoZone&helitackAvailable=false&fireLineAvailable=false&severeDroughtAvailable=false&showBurnIndex=false&forestWithSuppressionAvailable=false&hazbotRules=23&hazbotSidebar=true |
 | 24 | 2 | 4 | plainsTwoZone | [24.md](24.md) | http://localhost:8080/?preset=plainsTwoZone&helitackAvailable=false&fireLineAvailable=false&showBurnIndex=false&severeDroughtAvailable=false&forestWithSuppressionAvailable=false&hazbotRules=24&hazbotSidebar=true |
-| 25 | 2 | 5 | shrubThreeZone | [25.md](25.md) | http://localhost:8080/?preset=shrubThreeZone&helitackAvailable=false&fireLineAvailable=false&showBurnIndex=false&severeDroughtAvailable=false&forestWithSuppressionAvailable=false&hazbotRules=25&hazbotSidebar=true |
+| 25 | 2 | 5 | mountainTwoZone | [25.md](25.md) | http://localhost:8080/?preset=mountainTwoZone&helitackAvailable=false&fireLineAvailable=false&showBurnIndex=false&severeDroughtAvailable=false&forestWithSuppressionAvailable=false&hazbotRules=25&hazbotSidebar=true |
 | 32 | 3 | 2 | threeGreenZonePlains | [32.md](32.md) | http://localhost:8080/?preset=threeGreenZonePlains&helitackAvailable=false&fireLineAvailable=false&showBurnIndex=false&severeDroughtAvailable=false&hazbotRules=32&hazbotSidebar=true |
 | 33 | 3 | 3 | mountainTwoZone | [33.md](33.md) | http://localhost:8080/?preset=mountainTwoZone&helitackAvailable=false&fireLineAvailable=false&showBurnIndex=false&severeDroughtAvailable=false&hazbotRules=33&hazbotSidebar=true |
 | 34 | 3 | 4 | shrubThreeZone | [34.md](34.md) | http://localhost:8080/?preset=shrubThreeZone&helitackAvailable=false&fireLineAvailable=false&showBurnIndex=true&severeDroughtAvailable=false&hazbotRules=34&hazbotSidebar=true |
@@ -163,11 +163,11 @@ end to end through the engine.
 |---------|--------|------------------|--------------------------|
 | 23 | plainsTwoZone | cats 1–5 ✓ | none |
 | 24 | plainsTwoZone | cats 1–5 ✓ | none |
-| 25 | shrubThreeZone | cats 1–4 ✓ | cats 5 & 6 stub-gated (`SparksAtTopAndBottom` → WM-15) |
+| 25 | mountainTwoZone | cats 1–4 ✓ | cats 5 & 6 stub-gated (`SparksAtTopAndBottom` → WM-15) |
 | 32 | threeGreenZonePlains | cats 1–6 ✓ | none |
 | 33 | mountainTwoZone | cats 1–6 ✓ | none |
 | 34 | shrubThreeZone | cats 1–4 ✓ | none — `sawIntenseFire` was dropped in WM-18; cat 4 now uses `triedAllVegetations` |
-| 35 | mountainTwoZone | cats 1, 3–7 ✓ | cat 2 unreachable (shadowed by cat 3 — sheet-quality issue, see [TBD.md §4](../../src/hazbot/TBD.md)) |
+| 35 | mountainTwoZone | cats 1–7 ✓ | none — cat 3 gained a `setAnyVar AND` guard in the 2026-06-02 sheet, so cat 2 is reachable again (see [TBD.md §4](../../src/hazbot/TBD.md)) |
 | 42 | defaultTwoZone | cats 1–3 ✓ | none |
 | 45 | townsThreeZone | cats 1–3 ✓ | cat 4 stub-gated (`Helitack` → WM-28); cat 3 stub-degraded (`NOT (usedFireline AND usedHelitack)` collapses to TRUE — over-matches fireline+helitack runs) |
 | 47 | dryTownsThreeZone | cats 1–5 ✓ | cat 3 stub-degraded (`NOT (Fireline OR Helitack)` → `NOT Fireline` — over-matches helitack-only runs); cats 4/5 helitack arm dead, fireline arm reachable |

--- a/src/hazbot/TBD.md
+++ b/src/hazbot/TBD.md
@@ -104,19 +104,20 @@ Items where the source data should be corrected before the next re-extract:
   paired-reading primitive in the DSL today (see §6). Either downgrade the
   sheet's spec to single-reading, or extend the DSL.
 - **Typos that don't currently break anything but should be fixed at
-  source**: `"SimualtionStarted"` (rule-sets/23.ts:101), `"neecessarily"`
-  (multiple), `"whiel"` (33.ts:98), `"magitude"` / `"magnituide"` (24.ts,
-  33.ts) — these are in Details prose only, not parsed by the engine, but
-  they survive re-extracts.
-- **Tab 35 Cat 2 is unreachable (shadowed by Cat 3).** Cat 2 is
-  `ranSimulation AND NOT setAnyVar` and Cat 3 is
-  `ranSimulation WITH NOT ForestWAWOSuppression`. Any default run that
-  satisfies Cat 2 also lacks the forest-w/wo-suppression pairing, so it
-  satisfies Cat 3 — and Cat 3 > Cat 2 wins. Tab 33's analogous Cat 3
-  carries a `setAnyVar AND` guard that prevents the same shadowing; tab 35's
-  does not. The faithful extraction is committed (the extraction matches the
-  sheet); the fix is a sheet-side edit to add the missing `setAnyVar AND`
-  guard. Flagged here per WM-18 R11a.
+  source.** As of the 2026-06-02 re-extract, `"SimualtionStarted"` and
+  `"whiel"` have been corrected at source and no longer appear. Still
+  outstanding: `"neecessarily"` (multiple — 23/24/32/35/42.ts) and
+  `"magitude"` / `"magnituide"` (24/33/34/35/42.ts). These are in Details
+  prose only, not parsed by the engine, but they survive re-extracts.
+- **Tab 35 Cat 2 shadowing — RESOLVED (2026-06-02 workbook).** Cat 2 is
+  `ranSimulation AND NOT setAnyVar`; Cat 3 was previously
+  `ranSimulation WITH NOT ForestWAWOSuppression`, which any default run
+  satisfying Cat 2 also satisfied — and Cat 3 > Cat 2 won, leaving Cat 2
+  unreachable. The 2026-06-02 sheet adds the predicted `setAnyVar AND` guard
+  (Cat 3 is now `setAnyVar AND ranSimulation WITH NOT ForestWAWOSuppression`),
+  matching tab 33's analogous Cat 3. A default run (NOT setAnyVar) no longer
+  satisfies Cat 3, so Cat 2 is reachable again. Fixed at source per WM-18
+  R11a; carried in by the re-extract.
 
 ---
 

--- a/src/hazbot/rule-sets/23.ts
+++ b/src/hazbot/rule-sets/23.ts
@@ -24,7 +24,7 @@ export const ruleSet23: RuleSet<WildfireDefaults> = {
 3. Setup panel outlined; coach mark points to Setup panel`,
       arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 3)
 2. Hazbot: Now click the Setup button. (Step 2 of 3)
-3. Hazbot: Click each zone and change its drought conditions to match the instructions. Then run the model again. (Step 3 of 3)
+3. Hazbot: Click each zone to change its drought conditions to match the instructions. Then run the model again. (Step 3 of 3)
 [Got it!]`,
       expression: "NOT setAnyZoneVar AND ranSimulation",
     },
@@ -38,7 +38,8 @@ export const ruleSet23: RuleSet<WildfireDefaults> = {
 3. Setup panel outlined; coach mark points to Setup panel`,
       arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 3)
 2. Hazbot: Now click the Setup button. (Step 2 of 3)
-3. Hazbot: Adjust the controls so the zones match the photos. (Step 3 of 3)`,
+3. Hazbot: Adjust the controls so the zones match the photos. (Step 3 of 3)
+[Got it!]`,
       expression: "setAnyZoneVar AND ranSimulation WITH NOT CorrectZoneSetup",
     },
     {
@@ -48,7 +49,8 @@ export const ruleSet23: RuleSet<WildfireDefaults> = {
 [Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
 2. Coach mark (no pointer) centered top
-3. Spark button outlined`,
+     - If 2 sparks were placed, do not outline the Spark button.
+     - If only one spark was placed, then the Spark button is outlined.`,
       arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 2)
 2. Hazbot: Place one spark in Zone 1 and one spark in Zone 2, then run the model again. (Step 2 of 2)
 [Got it!]`,

--- a/src/hazbot/rule-sets/24.ts
+++ b/src/hazbot/rule-sets/24.ts
@@ -9,7 +9,7 @@ export const ruleSet24: RuleSet<WildfireDefaults> = {
     {
       id: 1,
       studentAction: "Did not run the simulation. A.k.a. Click button (before they do anything else)",
-      feedback: `Hazbot: Hello, again! I will analyze your model after you run it! Scroll up and follow the instructions at the top of the page!
+      feedback: `Hazbot: Hello, again! I will analyze your model after you run it. Scroll up and follow the instructions at the top of the page!
 [Okay]`,
       visualFeedback: "",
       expression: "NOT ranSimulation",
@@ -26,14 +26,15 @@ export const ruleSet24: RuleSet<WildfireDefaults> = {
       arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 4)
 2. Hazbot: Now click the Setup button. (Step 2 of 4)
 3. Hazbot: Click the Next button. (Step 3 of 4)
-4. Change the Wind Direction and Speed. Then run the model again. (Step 4 of 4)
+4. Change the Wind Direction and Wind Speed. Then run the model again. (Step 4 of 4)
 [Got it!]`,
       expression: "uniqueNonZeroWindValuesUsed.size == 0 AND NOT setAnyZoneVar AND ranSimulation",
     },
     {
       id: 3,
       studentAction: "Ran the simulation with zone setups changed but without wind speed or wind direction changed.",
-      feedback: "Hazbot: Let’s focus on wind. You can change the wind in the model Setup! [Show me]",
+      feedback: `Hazbot: Let’s focus on wind. You can change the wind in the model Setup!
+[Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
 2. Setup button outlined; coach mark points to Setup button
 3. Next button on the Setup panel outlined; coach mark points to Next button
@@ -41,14 +42,15 @@ export const ruleSet24: RuleSet<WildfireDefaults> = {
       arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 4)
 2. Hazbot: Now click the Setup button. (Step 2 of 4)
 3. Hazbot: Click the Next button. (Step 3 of 4)
-4. Change the Wind Direction and Speed. Then run the model again. (Step 4 of 4)
+4. Change the Wind Direction and Wind Speed. Then run the model again. (Step 4 of 4)
 [Got it!]`,
       expression: "uniqueNonZeroWindValuesUsed.size == 0 AND setAnyZoneVar",
     },
     {
       id: 4,
       studentAction: "Ran the simulation once with a different wind speed or a direction",
-      feedback: "Hazbot: Keep going! Setup the model with different wind settings to compare!",
+      feedback: `Hazbot: Keep going! Set up the model with different wind settings to compare!
+[Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
 2. Setup button outlined; coach mark points to Setup button
 3. Next button on the Setup panel outlined; coach mark points to Next button
@@ -56,7 +58,7 @@ export const ruleSet24: RuleSet<WildfireDefaults> = {
       arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 4)
 2. Hazbot: Now click the Setup button. (Step 2 of 4)
 3. Hazbot: Click the Next button. (Step 3 of 4)
-4. Change the Wind Direction and Speed. Then run the model again. (Step 4 of 4)
+4. Change the Wind Direction and Wind Speed. Then run the model again. (Step 4 of 4)
 [Got it!]`,
       expression: "NOT (uniqueWindValuesUsed.size > 1) AND uniqueNonZeroWindValuesUsed.size > 0",
     },

--- a/src/hazbot/rule-sets/25.ts
+++ b/src/hazbot/rule-sets/25.ts
@@ -20,7 +20,7 @@ export const ruleSet25: RuleSet<WildfireDefaults> = {
       feedback: `Hazbot: I only see 1 spark. Make sure each zone has a spark!
 [Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
-2. Coach mark (no pointer) centered top`,
+2. Spark button outlined; coach mark (no pointer) centered top`,
       arrowText: `1. Hazbot: Restart your model first. (Step 1 of 2)
 2. Hazbot: Place one spark in Zone 1 and one spark in Zone 2, then run the model again. (Step 2 of 2)
 [Got it!]`,
@@ -41,26 +41,34 @@ export const ruleSet25: RuleSet<WildfireDefaults> = {
     {
       id: 4,
       studentAction: "Ran the simulation and placed two sparks, but not at the top and bottom of the mountain",
-      feedback: "Hazbot: Make sure to place one spark at the top of a mountain and one at the bottom!",
-      visualFeedback: "Arrows pointing to the top and bottom of a mountain on the visual display (one in each zone)",
+      feedback: `Hazbot: Make sure to place one spark at the bottom of a mountain and one at the top!
+[Show me]`,
+      visualFeedback: `1. Restart button outlined; coach mark points to Restart button
+2. Coach mark (no pointer) with images of the bottom of a mountain and top of a mountain  plus arrows pointing to these, centered top`,
+      arrowText: `1. Hazbot: Restart your model first. (Step 1 of 2)
+2. Hazbot: Place one spark at the bottom of a mountain in one zone and one spark at the top of a mountain in the other zone, then run the model again. (Step 2 of 2)
+[Got it!]`,
       expression: "ranSimulation WITH OneSparkPerZone AND NOT SparksAtTopAndBottom",
     },
     {
       id: 5,
       studentAction: "Ran the simulation with one spark at the top and one at the bottom of the mountain but with different zone setups.",
-      feedback: "Hazbot: Looks like the two zones are different. Make sure they have the same vegetation and drought!",
+      feedback: `Hazbot: Looks like the two zones are different. Make sure they have the same vegetation and drought!
+[Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
 2. Setup button outlined; coach mark points to Setup button
 3. Setup panel outlined; coach mark points to Setup panel`,
       arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 3)
 2. Hazbot: Now click the Setup button. (Step 2 of 3)
-3. Hazbot: Make sure the conditions are the same in each zone. (Step 3 of 3)`,
+3. Hazbot: Make sure the conditions are the same in each zone. (Step 3 of 3)
+[Got it!]`,
       expression: "ranSimulation WITH OneSparkPerZone AND SparksAtTopAndBottom AND NOT UniformZoneSettings",
     },
     {
       id: 6,
       studentAction: "Ran the simulation with one spark at the top and one at the bottom of the mountain with the same zone setups.",
-      feedback: "Hazbot: Great job! You’re ready to answer the questions below.",
+      feedback: `Hazbot: Great job! You’re ready to answer the questions below.
+[Hooray!]`,
       visualFeedback: "Confetti animation or subtle celebratory visual",
       expression: "ranSimulation WITH OneSparkPerZone AND SparksAtTopAndBottom AND UniformZoneSettings",
     }

--- a/src/hazbot/rule-sets/32.ts
+++ b/src/hazbot/rule-sets/32.ts
@@ -31,7 +31,8 @@ export const ruleSet32: RuleSet<WildfireDefaults> = {
     {
       id: 3,
       studentAction: "Ran the simulation with drought changed but without three different vegetation types assigned (one per zone)",
-      feedback: "Hazbot: Hmm, I don’t see all vegetation types. Let’s set the zones to grass, shrub, and forest! [Show me]",
+      feedback: `Hazbot: Hmm, I don’t see all vegetation types. Let’s set the zones to grass, shrub, and forest!
+[Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
 2. Setup button outlined; coach mark points to Setup button
 3. Setup panel outlined; coach mark points to Setup panel`,
@@ -44,31 +45,34 @@ export const ruleSet32: RuleSet<WildfireDefaults> = {
     {
       id: 4,
       studentAction: "Ran the simulation with 3 different vegetation types assigned (one in each zone) and different drought levels between zones",
-      feedback: "Hazbot: To compare vegetation, make sure the drought level is the same for each zone!",
+      feedback: `Hazbot: To compare vegetation, make sure the drought level is the same for each zone!
+[Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
 2. Setup button outlined; coach mark points to Setup button
 3. Setup panel outlined; coach mark points to Setup panel`,
       arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 3)
 2. Hazbot: Now click the Setup button. (Step 2 of 3)
-3. Hazbot: Click each zone and make sure the drought is the same. Then run the model again. (Step 3 of 3)
+3. Hazbot: Click each zone and make sure the drought level is the same. Then run the model again. (Step 3 of 3)
 [Got it!]`,
       expression: "ranSimulation WITH UniqueVegetationPerZone AND NOT UniformDroughtLevels",
     },
     {
       id: 5,
       studentAction: "Ran the simulation with 3 different vegetations (one in each zone), same drought, but without one spark in each zone)",
-      feedback: "Hazbot: I don’t see any sparks. Add one spark in each zone so you can compare wildfire spread!",
-      visualFeedback: "1. Spark button outlined; coach mark points to spark button",
-      arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 3)
-2. Hazbot: Now make sure there is a Spark in each zone. (Step 2 of 3)
-3. Hazbot: Run the model again. (Step 3 of 3)
+      feedback: `Hazbot: I don’t see three sparks. Add one spark in each zone so you can compare wildfire spread!
+[Show me]`,
+      visualFeedback: `1. Restart button outlined; coach mark points to Restart button
+2. Spark button outlined; coach mark points to spark button`,
+      arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 2)
+2. Hazbot: Now make sure there is a Spark in each zone. Then run the model again. (Step 2 of 2)
 [Got it!]`,
       expression: "ranSimulation WITH UniqueVegetationPerZone AND NOT OneSparkPerZone",
     },
     {
       id: 6,
       studentAction: "Ran the simulation with 3 different vegetations (one in each zone), same drought, and one spark in each zone",
-      feedback: "Hazbot: Great job comparing three types of vegetation! You’re ready to answer the questions below.",
+      feedback: `Hazbot: Great job comparing three types of vegetation! You’re ready to answer the questions below.
+[Hooray!]`,
       visualFeedback: "Confetti animation or subtle celebratory visual",
       expression: "ranSimulation WITH UniqueVegetationPerZone AND UniformDroughtLevels AND OneSparkPerZone",
     }

--- a/src/hazbot/rule-sets/33.ts
+++ b/src/hazbot/rule-sets/33.ts
@@ -31,7 +31,8 @@ export const ruleSet33: RuleSet<WildfireDefaults> = {
     {
       id: 3,
       studentAction: "Ran the simulation with other zone setup variables changed but without assigning forest with and without suppression",
-      feedback: "Hazbot: Don't forget to compare the two types of forest. I can help![Show me]",
+      feedback: `Hazbot: Don't forget to compare the two types of forest. I can help!
+[Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
 2. Setup button outlined; coach mark points to Setup button
 3. Setup panel outlined; coach mark points to Setup panel`,
@@ -44,18 +45,22 @@ export const ruleSet33: RuleSet<WildfireDefaults> = {
     {
       id: 4,
       studentAction: "Ran the simulation with zones with forest and forest w/ suppression, and a spark not placed in each zone",
-      feedback: "Hazbot: I do not see a spark in each zone. Let’s put one in each so you can compare wildfire spread.[Show me]",
-      visualFeedback: "1. Spark button outlined; coach mark points to spark button",
-      arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 3)
-2. Hazbot: Now make sure there is a Spark in each zone. (Step 2 of 3)
-3. Hazbot: Run the model again. (Step 3 of 3)
+      feedback: `Hazbot: I do not see a spark in each zone. Let’s put one in each so you can compare wildfire spread.
+[Show me]`,
+      visualFeedback: `1. Restart button outlined; coach mark points to Restart button
+2. Coach mark (no pointer) centered top
+     - If 2 sparks were placed, do not outline the Spark button.
+     - If only one spark was placed, then the Spark button is outlined.`,
+      arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 2)
+2. Hazbot: Now make sure there is a spark in each zone. Then run the model again. (Step 2 of 2)
 [Got it!]`,
       expression: "ranSimulation WITH ForestWAWOSuppression AND NOT OneSparkPerZone",
     },
     {
       id: 5,
       studentAction: "Ran the simulation with zones with forest and forest w/ suppression, a spark placed in each zone, but different drought between the zones",
-      feedback: "Hazbot: To compare forest types, make sure the drought level is the same in each zone![Show me]",
+      feedback: `Hazbot: To compare forest types, make sure the drought level is the same in each zone!
+[Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
 2. Setup button outlined; coach mark points to Setup button
 3. Setup panel outlined; coach mark points to Setup panel`,
@@ -68,7 +73,8 @@ export const ruleSet33: RuleSet<WildfireDefaults> = {
     {
       id: 6,
       studentAction: "Ran the simulation with zones with forest and forest w/ suppression, a spark in each zone, and same drought",
-      feedback: "Hazbot: Great job! You’re ready to answer the questions below.[Show me]",
+      feedback: `Hazbot: Great job! You’re ready to answer the questions below.
+[Hooray!]`,
       visualFeedback: "Confetti animation or subtle celebratory visual",
       expression: "ranSimulation WITH ForestWAWOSuppression AND OneSparkPerZone AND UniformDroughtLevels",
     }

--- a/src/hazbot/rule-sets/34.ts
+++ b/src/hazbot/rule-sets/34.ts
@@ -19,7 +19,7 @@ export const ruleSet34: RuleSet<WildfireDefaults> = {
       studentAction: "Ran the simulation(s) with default setup values only",
       feedback: `Hazbot: Looks like you haven’t changed the Setup yet. What conditions do you think will produce a high intensity fire?
 [Show me]`,
-      visualFeedback: `1. Arrow pointing to the Intensity scale.
+      visualFeedback: `0. Arrow pointing to the Intensity scale
 2. Restart button outlined; coach mark points to Restart button
 3. Setup button outlined; coach mark points to Setup button
 4. Setup panel outlined; coach mark points to Setup panel`,
@@ -34,19 +34,21 @@ export const ruleSet34: RuleSet<WildfireDefaults> = {
       studentAction: "Ran the simulation, with drought and wind changed but vegetation unchanged.",
       feedback: `Hazbot: Keep experimenting! What type of vegetation do you think will produce a high intensity fire?
 [Show me]`,
-      visualFeedback: `1. Restart button outlined; coach mark points to Restart button
+      visualFeedback: `0. Arrow pointing to the Intensity scale
+1. Restart button outlined; coach mark points to Restart button
 2. Setup button outlined; coach mark points to Setup button
 3. Setup panel outlined; coach mark points to Setup panel`,
       arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 3)
 2. Hazbot: Now click the Setup button. (Step 2 of 3)
-3. Hazbot: Click each zone and change the vegetation. Then run the model again. (Step 3 of 3)
+3. Hazbot: Click each zone and change the vegetation to create a high intensity fire. Then run the model again. (Step 3 of 3)
 [Got it!]`,
       expression: "setDroughtLevel AND setWind AND NOT setVegetation",
     },
     {
       id: 4,
       studentAction: "Ran the simulation two or more times, tested all four vegetation types, and changed drought and winds.",
-      feedback: "Hazbot: Great job! You’re ready to answer the questions below.",
+      feedback: `Hazbot: Great job! You’re ready to answer the questions below.
+[Hooray!]`,
       visualFeedback: "Confetti animation or subtle celebratory visual",
       expression: "setDroughtLevel AND setWind AND triedAllVegetations",
     }

--- a/src/hazbot/rule-sets/35.test.ts
+++ b/src/hazbot/rule-sets/35.test.ts
@@ -2,21 +2,21 @@ import { ruleSet35 } from "./35";
 import { makeWildfireEngine, matchAgainst, mkReading } from "./test-helpers";
 import { WildfireDefaults, WildfireReading, WildfireZone } from "../wildfire/types";
 
-// Tab 35 categories (regenerated from the 2026-05-22 sheet; Cat 100 dropped):
+// Tab 35 categories (regenerated from the 2026-06-02 sheet; Cat 100 dropped):
 //   1: NOT ranSimulation
 //   2: ranSimulation AND NOT setAnyVar
-//   3: ranSimulation WITH NOT ForestWAWOSuppression
+//   3: setAnyVar AND ranSimulation WITH NOT ForestWAWOSuppression
 //   4: ranSimulation WITH ForestWAWOSuppression AND NOT UniformDroughtLevels
 //   5: ranSimulation WITH ForestWAWOSuppression AND NOT UniformTerrainTypes
 //   6: ranSimulation WITH ForestWAWOSuppression AND UniformTerrainTypes AND UniformDroughtLevels AND NOT OneSparkPerZone
 //   7: ranSimulation WITH ForestWAWOSuppression AND UniformTerrainTypes AND UniformDroughtLevels AND OneSparkPerZone
 //
-// Cat 2 is UNREACHABLE: cat 3 (`ranSimulation WITH NOT ForestWAWOSuppression`)
-// has no setAnyVar guard, so any default run that satisfies cat 2 also lacks the
-// forest pairing and thus satisfies cat 3 — cat 3 always shadows cat 2. (Tab 33's
-// analogous cat 3 carries a `setAnyVar AND` guard; tab 35's does not.) This is a
-// faithful extraction of a sheet-quality issue, flagged to the sheet author per
-// the WM-18 spec's Out of Scope. Cat 2 is excluded from R9 per-category coverage.
+// Cat 2 is now REACHABLE. The 2026-06-02 sheet added a `setAnyVar AND` guard to
+// cat 3 (was `ranSimulation WITH NOT ForestWAWOSuppression`, now
+// `setAnyVar AND ranSimulation WITH NOT ForestWAWOSuppression`), matching tab 33's
+// analogous cat 3. A default run (NOT setAnyVar) no longer satisfies cat 3, so it
+// falls through to cat 2 — the prior shadowing (flagged per WM-18 R11a) is fixed
+// at source. All seven categories now have R9 per-category coverage.
 // No stub-gated category — the (e) shape is N/A.
 
 // SIMINIT defaults for tab 35: 2 zones Mountains / Shrub / Mild Drought, wind 0/0.
@@ -76,7 +76,8 @@ describe("ruleSet 35 — per-rule-set behavior sweep", () => {
 });
 
 describe("ruleSet 35 — R9 per-category coverage", () => {
-  // Cat 2 is unreachable (shadowed by cat 3 — see the file header) and excluded.
+  // Cat 2 is reachable again now that cat 3 carries a `setAnyVar AND` guard
+  // (see the file header). All seven categories are covered below.
   const e = () => makeWildfireEngine(ruleSet35, defaults);
   it("cat 1 — no run", () => expect(matchAgainst(ruleSet35, e(), [])).toBe(1));
   it("cat 3 — ran without the forest-with/without-suppression pairing", () =>
@@ -89,6 +90,6 @@ describe("ruleSet 35 — R9 per-category coverage", () => {
     expect(matchAgainst(ruleSet35, e(), [startReading({ zones: forestWW })])).toBe(6));
   it("cat 7 — forest pairing, uniform terrain+drought, one spark per zone", () =>
     expect(matchAgainst(ruleSet35, e(), [startReading({ zones: forestWW, sparks: sparksPerZone })])).toBe(7));
-  it("cat 2 is unreachable — an all-default run is shadowed by cat 3", () =>
-    expect(matchAgainst(ruleSet35, e(), [startReading()])).toBe(3));
+  it("cat 2 — an all-default run (no vars set) is no longer shadowed by cat 3", () =>
+    expect(matchAgainst(ruleSet35, e(), [startReading()])).toBe(2));
 });

--- a/src/hazbot/rule-sets/35.ts
+++ b/src/hazbot/rule-sets/35.ts
@@ -9,44 +9,44 @@ export const ruleSet35: RuleSet<WildfireDefaults> = {
     {
       id: 1,
       studentAction: "Did not run the simulation",
-      feedback: "Hazbot: You haven’t run the model yet. Run it before answering the questions.",
+      feedback: `Hazbot: You haven’t run the model yet. Run it before answering the questions.
+[Okay]`,
       visualFeedback: "",
       expression: "NOT ranSimulation",
     },
     {
       id: 2,
       studentAction: "Ran the simulation with default setup values only",
-      feedback: "Hazbot: Click “Setup” and change the conditions to compare forest with and without suppression. Then run the model again.",
+      feedback: `Hazbot: Click Setup and change the conditions to compare forest with and without suppression. Then run the model again.
+[Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
 2. Setup button outlined; coach mark points to Setup button
-3. Next button on the Setup panel outlined; coach mark points to Next button
-4. Wind section of Setup panel outlined; coach mark points to Setup panel`,
-      arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 4)
-2. Hazbot: Now click the Setup button. (Step 2 of 4)
-3. Hazbot: Set one zone to forest and the other zone to forest with suppression. (Step 3 of 4)
-4. Run the model again. (Step 4 of 4)
+3. Next button on the Setup panel outlined; coach mark points to Next button`,
+      arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 3)
+2. Hazbot: Now click the Setup button. (Step 2 of 3)
+3. Hazbot: Set one zone to forest and the other zone to forest with suppression. Then run the model again. (Step 3 of 3)
 [Got it!]`,
       expression: "ranSimulation AND NOT setAnyVar",
     },
     {
       id: 3,
       studentAction: "Ran the simulation with terrain, drought or wind changed but without assigning forest with and without suppression to each zone",
-      feedback: "Hazbot: Let’s focus on forests with and without suppression in the vegetation settings.",
+      feedback: `Hazbot: Let’s focus on forests with and without suppression in the vegetation settings.
+[Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
 2. Setup button outlined; coach mark points to Setup button
-3. Next button on the Setup panel outlined; coach mark points to Next button
-4. Wind section of Setup panel outlined; coach mark points to Setup panel`,
-      arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 4)
-2. Hazbot: Now click the Setup button. (Step 2 of 4)
-3. Hazbot: Set one zone to forest and the other zone to forest with suppression. (Step 3 of 4)
-4. Run the model again. (Step 4 of 4)
+3. Next button on the Setup panel outlined; coach mark points to Next button`,
+      arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 3)
+2. Hazbot: Now click the Setup button. (Step 2 of 3)
+3. Hazbot: Set one zone to forest and the other zone to forest with suppression. Then run the model again. (Step 3 of 3)
 [Got it!]`,
-      expression: "ranSimulation WITH NOT ForestWAWOSuppression",
+      expression: "setAnyVar AND ranSimulation WITH NOT ForestWAWOSuppression",
     },
     {
       id: 4,
       studentAction: "Ran the simulation with forest and forest with suppression assigned but with different drought levels between the zones",
-      feedback: "Hazbot: To compare forest types, make sure the both zones have the same drought level!",
+      feedback: `Hazbot: To compare forest types, make sure the both zones have the same drought level!
+[Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
 2. Setup button outlined; coach mark points to Setup button
 3. Setup panel outlined; coach mark points to Setup panel`,
@@ -59,7 +59,8 @@ export const ruleSet35: RuleSet<WildfireDefaults> = {
     {
       id: 5,
       studentAction: "Ran the simulation with forest with and without suppression assigned but different terrains between the zones",
-      feedback: "Hazbot: To compare forest types, make sure both zones have mountains.",
+      feedback: `Hazbot: To compare forest types, make sure both zones have mountains.
+[Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
 2. Setup button outlined; coach mark points to Setup button
 3. Setup panel outlined; coach mark points to Setup panel`,
@@ -72,19 +73,22 @@ export const ruleSet35: RuleSet<WildfireDefaults> = {
     {
       id: 6,
       studentAction: "Ran the simulation with forest with and without suppression, same drought and terrain types between zones, but without a spark in each zone",
-      feedback: "Hazbot: I don’t see a spark in both zones. Add one spark to each so you can compare wildfire spread.",
+      feedback: `Hazbot: I don’t see a spark in both zones. Add one spark to each so you can compare wildfire spread.
+[Show me]`,
       visualFeedback: `1. Restart button outlined; coach mark points to Restart button
 2. Coach mark (no pointer) centered top
-3. Spark button outlined`,
+     - If 2 sparks were placed, do not outline the Spark button.
+     - If only one spark was placed, then the Spark button is outlined.`,
       arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 2)
-2. Hazbot: Place one spark in Zone 1 and one spark in Zone 2, then run the model again. (Step 2 of 2)
+2. Hazbot: Place one Spark in Zone 1 and one Spark in Zone 2, then run the model again. (Step 2 of 2)
 [Got it!]`,
       expression: "ranSimulation WITH ForestWAWOSuppression AND UniformTerrainTypes AND UniformDroughtLevels AND NOT OneSparkPerZone",
     },
     {
       id: 7,
       studentAction: "Ran the simulation with forest with and without suppression, same drought and terrain between zones, and a spark in each zone",
-      feedback: "Hazbot: Great job! You’re ready to answer the questions below.",
+      feedback: `Hazbot: Great job! You’re ready to answer the questions below.
+[Hooray!]`,
       visualFeedback: "Confetti animation or subtle celebratory visual",
       expression: "ranSimulation WITH ForestWAWOSuppression AND UniformTerrainTypes AND UniformDroughtLevels AND OneSparkPerZone",
     }

--- a/src/hazbot/rule-sets/42.ts
+++ b/src/hazbot/rule-sets/42.ts
@@ -17,10 +17,12 @@ export const ruleSet42: RuleSet<WildfireDefaults> = {
     {
       id: 2,
       studentAction: "Ran the simulation with a changed vegetation type, drought, or wind.",
-      feedback: "Hazbot: Let’s run the model using the original settings!",
-      visualFeedback: "1. Reload button outlined; coach mark points to Reload button",
+      feedback: `Hazbot: Let’s run the model using the original settings!
+[Show me]`,
+      visualFeedback: `1. Reload button outlined; coach mark points to Reload button
+2. Start button outlined; coach mark points to Start button`,
       arrowText: `1. Hazbot: First, Reload your model. (Step 1 of 2)
-2. Hazbot: Click to start to run the model! (Step 2 of 2)
+2. Hazbot: Click to Start to run the model! (Step 2 of 2)
 [Got it!]`,
       expression: "setAnyVar",
     },
@@ -28,7 +30,8 @@ export const ruleSet42: RuleSet<WildfireDefaults> = {
       id: 3,
       studentAction: `Ran the simulation 
 without changed variables.`,
-      feedback: "Hazbot: Great job! You’re ready to answer the questions below.",
+      feedback: `Hazbot: Great job! You’re ready to answer the questions below.
+[Hooray!]`,
       visualFeedback: "Confetti animation or subtle celebratory visual",
       expression: "ranSimulation AND NOT setAnyVar",
     }

--- a/src/hazbot/rule-sets/45.ts
+++ b/src/hazbot/rule-sets/45.ts
@@ -19,9 +19,11 @@ export const ruleSet45: RuleSet<WildfireDefaults> = {
       studentAction: "Ran the simulation with a changed vegetation type, drought, or wind.",
       feedback: `Hazbot: Looks like you changed the Setup. Let’s run the model using the original settings!
 [Show me]`,
-      visualFeedback: "1. Reload button outlined; coach mark points to Reload button",
-      arrowText: `Hazbot: Click this button to reset the model.
-Hazbot: Now you can run the model.`,
+      visualFeedback: `1. Reload button outlined; coach mark points to Reload button
+2. Start button outlined; coach mark points to Start button`,
+      arrowText: `1. Hazbot: First, Reload your model. (Step 1 of 2)
+2. Hazbot: Click Start to run the model! (Step 2 of 2)
+[Got it!]`,
       expression: "ranSimulation WITH NOT DefaultVars",
     },
     {
@@ -35,17 +37,20 @@ OR
 with helitacks only 
  
 in a single or multiple trials.`,
-      feedback: "Hazbot: Try using both the firelines and helitacks!",
-      visualFeedback: "1. Helitack and firelines buttons outlined; coach mark points to buttons",
-      arrowText: `1. Hazbot: Make sure you try both firelines and helitacks. (Step 1 of 2)
-2. Hazbot: Click to start to run the model! (Step 2 of 2)
+      feedback: `Hazbot: Try using both the firelines and helitacks!
+[Show me]`,
+      visualFeedback: `1. Restart button outlined; coach mark points to Restart button
+2. Fireline and Helitack buttons outlined (both are disabled) and Start button outlined; coach mark points to Fireline/Helitack buttons`,
+      arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 2)
+2. Hazbot: Add both a Fireline and a Helitack while the model is running. Click Start to begin! (Step 2 of 2)
 [Got it!]`,
       expression: "NOT (usedFireline AND usedHelitack) AND ranSimulation WITH DefaultVars",
     },
     {
       id: 4,
       studentAction: "Ran the model with no setup changes and with both firelines and helitacks used in a single or multiple trials.",
-      feedback: "Hazbot: Great job! You’re ready to answer the questions below.",
+      feedback: `Hazbot: Great job! You’re ready to answer the questions below.
+[Hooray!]`,
       visualFeedback: "Confetti animation or subtle celebratory visual",
       expression: "ranSimulation WITH DefaultVars AND Fireline AND ranSimulation WITH DefaultVars AND Helitack",
     }

--- a/src/hazbot/rule-sets/47.ts
+++ b/src/hazbot/rule-sets/47.ts
@@ -19,36 +19,42 @@ export const ruleSet47: RuleSet<WildfireDefaults> = {
       studentAction: "Ran the simulation with changed vegetation type, drought, or wind.",
       feedback: `Hazbot: Looks like you changed the Setup. Let’s run the model using the original settings!
 [Show me]`,
-      visualFeedback: "1. Reload button outlined; coach mark points to Reload button",
+      visualFeedback: `1. Reload button outlined; coach mark points to Reload button
+2. Start button outlined; coach mark points to Start button`,
       arrowText: `1. Hazbot: First, Reload your model. (Step 1 of 2)
-2. Hazbot: Click to start to run the model! (Step 2 of 2)
+2. Hazbot: Click Start to run the model! (Step 2 of 2)
 [Got it!]`,
       expression: "ranSimulation WITH NOT DefaultVars",
     },
     {
       id: 3,
       studentAction: "Ran with original settings and with neither fireline nor helitack (but did not do the next step of running with fireline or helitack yet)",
-      feedback: "Hazbot: Try using firelines and helitacks to contain the fire! [Show me]",
-      visualFeedback: "1. Helitack and firelines buttons outlined; coach mark points to buttons",
-      arrowText: `1. Hazbot: Make sure you try both firelines and helitacks. (Step 1 of 2)
-2. Hazbot: Click to start to run the model! (Step 2 of 2)
+      feedback: `Hazbot: Try using firelines and helitacks to contain the fire!
+[Show me]`,
+      visualFeedback: `1. Restart button outlined; coach mark points to Restart button
+2. Fireline and Helitack buttons outlined (both are disabled) and Start button outlined; coach mark points to Fireline/Helitack buttons`,
+      arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 2)
+2. Hazbot: Add both a Fireline and a Helitack while the model is running. Click Start to begin! (Step 2 of 2)
 [Got it!]`,
       expression: "ranSimulation WITH DefaultVars AND NOT (Fireline OR Helitack)",
     },
     {
       id: 4,
       studentAction: "Ran with original settings and with at least one fireline or helitack, but without first running with original settings with neither fireline nor helitack",
-      feedback: "Hazbot: Did you try running the model without firelines and helitacks to see where the fire spread?",
-      visualFeedback: "1. Restart the model; coach mark points to Restart button",
+      feedback: `Hazbot: Did you try running the model without firelines and helitacks to see where the fire spread?
+[Show me]`,
+      visualFeedback: `1. Restart the model; coach mark points to Restart button
+2. Start button outlined; coach mark points to Start button`,
       arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 2)
-2. Hazbot: Click to start to run the model! (Step 2 of 2)
+2. Hazbot: Click Start to run the model! (Step 2 of 2)
 [Got it!]`,
       expression: "NOT ranSimulation WITH DefaultVars AND NOT (Fireline OR Helitack) AND ranSimulation WITH DefaultVars AND (Fireline OR Helitack)",
     },
     {
       id: 5,
       studentAction: "Ran with original settings and with at least one fireline or helitack, after (or before) running with original settings with neither fireline nor helitack",
-      feedback: "Hazbot: Great job on this investigation! Keep working through the activity!",
+      feedback: `Hazbot: Great job on this investigation! Keep working through the activity!
+[Hooray!]`,
       visualFeedback: "Confetti animation or subtle celebratory visual",
       expression: "ranSimulation WITH DefaultVars AND NOT (Fireline OR Helitack) AND ranSimulation WITH DefaultVars AND (Fireline OR Helitack)",
     }

--- a/src/hazbot/rule-sets/54.ts
+++ b/src/hazbot/rule-sets/54.ts
@@ -32,16 +32,18 @@ export const ruleSet54: RuleSet<WildfireDefaults> = {
       id: 3,
       studentAction: "Ran with original vegetation setting and severe drought across all three zones but without fireline or helitack",
       feedback: "Hazbot: Try using firelines and helitacks to contain the fire! [Show me]",
-      visualFeedback: "1. Helitack and firelines buttons outlined; coach mark points to buttons",
-      arrowText: `1. Hazbot: Make sure you try both firelines and helitacks. (Step 1 of 2)
-2. Hazbot: Click to start to run the model! (Step 2 of 2)
+      visualFeedback: `1. Restart button outlined; coach mark points to Restart button
+2. Fireline and Helitack buttons outlined (both are disabled) and Start button outlined; coach mark points to Fireline/Helitack buttons`,
+      arrowText: `1. Hazbot: First, Restart your model. (Step 1 of 2)
+2. Hazbot: Add both a Fireline and a Helitack while the model is running. Click Start to begin! (Step 2 of 2)
 [Got it!]`,
       expression: "ranSimulation WITH DefaultVegetations AND SevereDroughts AND NOT (Fireline OR Helitack)",
     },
     {
       id: 4,
       studentAction: "Ran with original vegetation setting and severe drought across all three zones and with at least one fireline or helitack in one or more trials",
-      feedback: "Hazbot: Great job on this investigation! Keep working through the activity!",
+      feedback: `Hazbot: Great job on this investigation! Keep working through the activity!
+[Hooray!]`,
       visualFeedback: "Confetti animation or subtle celebratory visual",
       expression: "ranSimulation WITH DefaultVegetations AND SevereDroughts AND (Fireline OR Helitack)",
     }

--- a/src/hazbot/wildfire/rules-version.ts
+++ b/src/hazbot/wildfire/rules-version.ts
@@ -1,3 +1,3 @@
 // App-side rules version (per Req 20). Bumped per the policy in
 // docs/hazbot-update-workflow.md when sheet edits change rule semantics.
-export const APP_RULES_VERSION = 2;
+export const APP_RULES_VERSION = 3;


### PR DESCRIPTION
Re-ran scripts/extract-hazbot-sheets.js against
"Wildfire Hazbot Feedback Tables-2026-06-02.xlsx" — the first clean full regenerate of the rule-set modules now that WM-18 has landed (the "avoid a full re-extract until WM-18" caveat in the workflow doc and TBD.md is moot).

Editorial changes (feedback / visualFeedback / arrowText / details prose) across tabs 23, 24, 25, 32, 33, 34, 35, 42, 45, 47, 54, including new student-facing button labels ([Okay], [Show me], [Got it!], [Hooray!]), reworded coach-mark steps, and conditional spark-button visualFeedback notes. dsl-grammar.md and the rule-sets/index.ts barrel are unchanged (no parser or new-tab work), and no new factor-variable / sim-prop names were introduced.

Semantic fix (exactly one): tab 35 Cat 3 gains the predicted `setAnyVar AND` guard — was `ranSimulation WITH NOT ForestWAWOSuppression`, now `setAnyVar AND ranSimulation WITH NOT ForestWAWOSuppression`. This is the fix TBD.md §4 predicted for the tab-35 Cat 2 shadowing bug (WM-18 R11a): a default run (NOT setAnyVar) no longer satisfies Cat 3, so Cat 2 is reachable again, matching tab 33's analogous Cat 3.

- Bumped APP_RULES_VERSION 2 → 3 (the tab-35 change is semantic).
- Updated TBD.md §4: marked the tab-35 shadowing item RESOLVED; rechecked the other §4 items — the `SimualtionStarted` and `whiel` typos are now fixed at source, while `neecessarily` and `magitude`/`magnituide` remain (details-prose only; durable fix is sheet-side).
- Updated src/hazbot/rule-sets/35.test.ts: the R9 coverage test that encoded the old shadowing (Cat 2 unreachable) now asserts Cat 2 is reachable; header/comments updated. Five-shape sweep structure intact. No other rule-set test asserts on prose, so no other test drift.
- Regenerated docs/hazbot-validation/*.md playbooks.

localhost-urls.md decision: fixed ruleset 25's validation preset from shrubThreeZone (3-zone) to mountainTwoZone (the established 2-zone mountain preset, already used by tabs 33/35). Ruleset 25 is a 2-zone mountain activity (tab 25 references zone 1 / zone 2, i=0 and i=1), so the 3-zone preset was stale regardless of WM-15; fixing it here gives WM-15 a correct base. Also updated the tab-35 validation-status row to reflect Cat 2 being reachable again.

SparksAtTopAndBottom stays a stub (isStub: true) on this branch — that impl is WM-15 — so ruleset 25 Cat 5/6 remain stub-gated, as expected.

All tests pass (npm test: 557 passed) and lint is clean (0 errors).