### PR TITLE
feat: add Hazbot feedback coach mark [WM-16]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
+        "@concord-consortium/coachmarks": "0.0.1-pre.7",
         "@concord-consortium/lara-interactive-api": "^1.13.0",
         "@concord-consortium/log-monitor": "^1.0.0",
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
+        "@floating-ui/react": "^0.27.19",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.3",
         "@react-three/drei": "^9.72.2",
@@ -1884,6 +1886,32 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@concord-consortium/coachmarks": {
+      "version": "0.0.1-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/coachmarks/-/coachmarks-0.0.1-pre.7.tgz",
+      "integrity": "sha512-ksctgy3aAILEVgSRgdI1O8ggdF/pBcp6+QE30olQ29+QEsmaEdaw8tfU+zdzi13cGKXZDgFKMV2eQ/W8R/KvwA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@floating-ui/react": "^0.27.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/coachmarks/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@concord-consortium/lara-interactive-api": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.13.0.tgz",
@@ -2420,6 +2448,59 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -17605,6 +17686,12 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -20644,6 +20731,21 @@
       "dev": true,
       "optional": true
     },
+    "@concord-consortium/coachmarks": {
+      "version": "0.0.1-pre.7",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/coachmarks/-/coachmarks-0.0.1-pre.7.tgz",
+      "integrity": "sha512-ksctgy3aAILEVgSRgdI1O8ggdF/pBcp6+QE30olQ29+QEsmaEdaw8tfU+zdzi13cGKXZDgFKMV2eQ/W8R/KvwA==",
+      "requires": {
+        "clsx": "^2"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+        }
+      }
+    },
     "@concord-consortium/lara-interactive-api": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.13.0.tgz",
@@ -21066,6 +21168,46 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
       "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
       "dev": true
+    },
+    "@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "requires": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "requires": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "requires": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "requires": {
+        "@floating-ui/dom": "^1.7.6"
+      }
+    },
+    "@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
     },
     "@hapi/hoek": {
       "version": "9.3.0",
@@ -32210,6 +32352,11 @@
         "@pkgr/utils": "^2.3.1",
         "tslib": "^2.5.0"
       }
+    },
+    "tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="
     },
     "tapable": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
       "src/utilities/test-utils.ts"
     ],
     "moduleNameMapper": {
+      "^@concord-consortium/coachmarks/styles/": "identity-obj-proxy",
       "\\.svg$": "<rootDir>/__mocks__/svgMock.js",
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less|sass|scss)$": "identity-obj-proxy"
@@ -121,10 +122,12 @@
     "webpack-dev-server": "^4.15.0"
   },
   "dependencies": {
+    "@concord-consortium/coachmarks": "0.0.1-pre.7",
     "@concord-consortium/lara-interactive-api": "^1.13.0",
     "@concord-consortium/log-monitor": "^1.0.0",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
+    "@floating-ui/react": "^0.27.19",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.3",
     "@react-three/drei": "^9.72.2",

--- a/specs/WM-16-hazbot-feedback-panel.md
+++ b/specs/WM-16-hazbot-feedback-panel.md
@@ -1,0 +1,195 @@
+# WM-16 — Hazbot Feedback Panel (rendering matched-category feedback)
+
+**Jira**: https://concord-consortium.atlassian.net/browse/WM-16
+
+**Status**: **Closed**
+
+## Overview
+
+When a student clicks the Hazbot Analysis button, show a coach-mark popover anchored above the button that renders the feedback text for the rule-set category the student is currently in. This is the first of two stories; this story shows a single coach mark anchored to Hazbot, and a follow-on story adds a multi-step tour that highlights other elements.
+
+The Hazbot analysis engine (WM-10) has been classifying student behavior into pedagogical categories all along, but students have never seen its output. This story delivers the first student-facing surface for that feedback: clicking the Hazbot button opens a friendly speech-bubble popover above Hazbot with guidance tailored to what the student has (or hasn't) done. It is the MVP "actual feedback" deliverable.
+
+## Requirements
+
+- Render a coach-mark popover, anchored above the Hazbot button, when the student clicks the Hazbot button (`ui.showHazbotFeedback` becomes true).
+- The popover body is the `feedback` text of the engine's current `matchedCategory`, with the leading `Hazbot:` speaker prefix stripped.
+- The body supports **bold** emphasis (`**…**`), rendered by the coachmarks library's constrained, bold-focused Markdown subset (enabled by default, HTML escaped). *(Rendering is implemented and verified; **authoring** bold in the source Google Sheet + regenerating the rule-set files via `scripts/extract-hazbot-sheets.js` is **deferred to the PIs** — no shipping ruleset contains bold yet.)*
+- The bracket token in the feedback (`[…]`) supplies the action button's label; clicking it dismisses the popover. In v1 every action button dismisses regardless of label — including `[Show me]`, which starts the guided tour only once the follow-on story lands.
+- A `×` close button also dismisses the popover.
+- Pre-run, Category 1 ("Did not run the simulation") matches by default, so the same code path produces the pre-run message with no special-casing.
+- While the popover is open, the Hazbot button shows its "Large" state: only the robot avatar scales up (the button "back" keeps its size and `#c1daff` fill); pulsing is suppressed.
+- The popover uses the coachmarks `hazbot` theme.
+- Any dismissal (action button, `×`, or Escape) resets `ui.showHazbotFeedback` to `false`, and a subsequent Hazbot-button click reopens the popover with the then-current matched category.
+- Re-trigger is deferred for v1: the panel opens only on an explicit Hazbot-button click — no transition-based auto-open or re-glow, no cross-session persistence. (The existing post-run pulse from WM-6 still arms on run completion and clears on click.)
+
+### Acceptance criteria
+
+- Clicking the Hazbot button opens a popover anchored above Hazbot showing the current `matchedCategory`'s feedback body, with the leading `Hazbot:` prefix removed.
+- Pre-run, the popover shows Category 1's message via the same path (no special-casing).
+- Bold authored as `**…**` renders as bold in the popover.
+- The action button's label is the bracket token parsed from that category's feedback; clicking it closes the popover.
+- The `×` close button and the Escape key also close the popover.
+- Each of the three dismiss routes (action button, `×`, Escape) resets `ui.showHazbotFeedback` to `false`; clicking the Hazbot button again reopens with the then-current matched category.
+- While the popover is open, the button is in its "Large" state (only the avatar scaled up) and the pulse is suppressed; on close it returns to default.
+- Defensive guard: if `matchedCategory` is `null`, the click path does not error (guarded no-op, no popover). A loaded ruleset always floors to ≥1 (Category 1 = `NOT ranSimulation`), so this guard is exercised by mocking, not via the UI.
+
+## Technical Notes
+
+- **Dependency**: wildfire-model depends on `@concord-consortium/coachmarks@0.0.1-pre.7` (published to npm; peer dep `@floating-ui/react` ^0.27), pinned in `package.json` and imported as `createCoachmarksEngine` plus the side-effect stylesheet `@concord-consortium/coachmarks/styles/hazbot`. The release provides, in the `hazbot` theme: **Chakra Petch** for the popover description (Lato stays for labels/buttons); a **constrained Markdown subset** in `description` (bold `**…**`, HTML escaped, default-on with an opt-out flag; `description`/`title` stay `string`); and the **styled close button** (white disc, 3px `#0050C4` ring, blue glyph, top-right, hover/select states — opt in via `showButtons` including `"close"`). The library also carries top-level `main`/`module`/`types` fields (added in `pre.7`) so it resolves under wildfire-model's classic `moduleResolution: node` type-check. For local library development alongside this repo, use `yalc` (workflow doc: `~/tmp/wildfire-yalc.md`).
+- **Anchor**: `engine.highlight({ element: avatarEl, popover: { side: "top", align: "center", description: <body> } })`, via a React ref to the **robot-face** `.avatar` span (not the button wrapper, not a `data-testid` query), so the arrow points at Hazbot's face and tracks it as it scales up. The popover renders from within `HazbotButton`, which holds the ref. `ringElement` targets the outer button (inert here — `showOutlineRing: false`).
+- **Feedback parsing** (`parseFeedback`, exported for tests): parse the matched category's own `feedback` into (a) body prose with the leading `Hazbot:` prefix removed and (b) the bracket-token button label. Exactly one bracket token per feedback, on the last line. The parsed token becomes the popover's **`doneBtnText`** — a single-step `highlight()` renders `doneBtnText` (the step is last), not `nextBtnText`. Bold `**…**` is left intact in the body for the library to render.
+- **Matched category → feedback**: `matchedCategory` is a category `id`; look up `ruleSet.categories.find(c => c.id === matchedCategory)`. Guard the `null`/no-engine case.
+- **React integration**: `createCoachmarksEngine()` is created/destroyed inside a `useEffect` keyed on `ui.showHazbotFeedback`. The matched category is read **directly** (`getAnalysisEngine()` + `computeMatchedCategoryForEngine()`) at open time, not via the reactive `useAnalysisEngine()` hook — the value is only needed when the panel opens, so no provider/hook wiring is required. `HazbotButton` is a MobX `observer`.
+- **Dismiss → flag reset (re-open correctness)**: the panel is driven off the `ui.showHazbotFeedback` observable, so dismissal must flip it back to `false` or the effect won't re-run on the next click. The action button ("Okay"/Done) reaches `destroy()` directly (fires `onDestroyed`); `×`/Escape fire `onCancelRequested`; `onDestroyed` fires on **every** teardown path. So wire `onCancelRequested → engine.destroy()` and reset `ui.showHazbotFeedback = false` in `onDestroyed` — one handler covering all three routes.
+- **Scale-up / "Large" state**: `.hazbotButtonWrap.coached .avatar { transform: scale(1.525); transform-origin: bottom center }`, gated on `ui.showHazbotFeedback`; the button "back" (size + `#c1daff` fill + border) is unchanged. The coach mark opens only after the avatar transform's `transitionend` (or a 400ms fallback) so floating-ui anchors to the enlarged robot.
+- **Robot focus ring**: the button uses `onMouseDown` `preventDefault` (no focus on mouse click) and the avatar has `:focus { outline: none }`, so the library's focus-restore-to-anchor on close shows no ring; keyboard focus to the real button still works.
+- **Arrow / offset**: the consumer configures `arrow: { width: 36, height: 18, strokeWidth: 3 }` (strokeWidth matches the theme's 3px border) and `popoverOffset: 25` (gap between the arrow tip and the robot).
+
+## Testing
+
+- **Unit (Jest + React Testing Library)**, no WebGL ([hazbot-button.test.tsx](src/components/hazbot-button.test.tsx)): `parseFeedback` directly (prefix strip, token→label, **bold** preserved); and the panel wiring with the **coachmarks engine and analysis-engine reads mocked** — what the engine is opened with (parsed `description`, `doneBtnText`, `showButtons`), the `matchedCategory`→feedback mapping and the no-engine/`null` guard, `ui.showHazbotFeedback` reset via `onDestroyed` (all three dismiss routes) and `onCancelRequested → destroy()`, reopen recomputing the then-current category, and the `.coached` toggle. The library's popover rendering / anchor placement are covered by the library's own tests + Playwright, so these unit tests mock `createCoachmarksEngine` rather than driving the portalled popover; the open-after-scale-up step is exercised by advancing the 400ms fallback timer. Jest needs a `moduleNameMapper` entry stubbing the theme's CSS subpath imports (`^@concord-consortium/coachmarks/styles/` → `identity-obj-proxy`).
+- **Visual (Playwright vs Zeplin)** for the open/scale-up/dismiss/scale-down flow, anchor placement, and fonts — design targets, not unit-asserted.
+- No new Cypress spec required for v1.
+
+## Out of Scope
+
+- The multi-step guided **tour** / walk-through (stepping through `Category.arrowText`, anchoring to Restart/Setup/etc.) — the follow-on second story.
+- The **visual overlay** (outlines, pointers at zone tabs, dashed zone lines) — Visual-feedback overlay renderer sibling story.
+- **Confetti / celebration** on the success (terminal/highest-id) category — WM-9.
+- **Cross-session persistence** of "user already saw this category's feedback" — depends on AP-73 / NEW-7.
+- Coach marks anchored to anything other than the Hazbot button (the tour story).
+- **Known limitation (v1)**: action buttons whose label implies a walk-through (e.g. `[Show me]`) only dismiss this story; the walk-through behind them lands with the follow-on tour story. The label is still parsed per-category so it renders correctly.
+
+## Not Yet Implemented
+
+- **Bold-emphasis authoring** in the rule-set feedback — deferred to the PIs. The library *renders* bold (`**…**`) and `parseFeedback` preserves it, and it's verified end-to-end, but the bold markup must be authored in the source Google Sheet and the rule-set files regenerated (`scripts/extract-hazbot-sheets.js`); no shipping ruleset contains bold yet.
+
+## Decisions
+
+### Re-trigger / cooldown behavior — does the panel auto-pop or just re-glow?
+**Context**: The v1 working assumption was "per matched-category transition" (auto-open or re-glow on category change). PM input was pending.
+**Options considered**:
+- A) On transition, re-arm the pulse/glow only; panel opens on explicit click (reuses `hazbotPulseArmed`).
+- B) On transition, auto-open the panel.
+- C) Defer entirely: panel opens only on click, no transition-based re-trigger in v1.
+
+**Decision**: C — panel opens only on click; no transition-based re-trigger in v1.
+
+---
+
+### How should wildfire-model consume the coachmarks library for this story?
+**Context**: The library wasn't on npm yet and wasn't a dependency. The font/Markdown/close-button work and the publish were prerequisites.
+**Options considered**:
+- A) Publish to npm first, then add as a normal versioned dependency.
+- B) Use `yalc` for local development now, switch to the npm version before merge.
+- C) Add as a git URL / git tag dependency.
+
+**Decision**: B — develop against the library via `yalc`, then publish to npm and pin the version (`0.0.1-pre.7`) in `package.json` before merge.
+
+---
+
+### What does the `[Show me]` button do in this story (no tour yet)?
+**Context**: Intermediate categories use `[Show me]`, which in the full design starts the guided tour — but the tour is the follow-on story. Category ids vary by ruleset, so the label is always parsed per-category, never keyed off a fixed id.
+**Options considered**:
+- A) `[Show me]` simply dismisses (same as Okay) until the tour story lands.
+- B) Rendered but disabled/no-op until the tour lands.
+- C) Render whatever bracket token the data provides; every action button is "dismiss" this story.
+
+**Decision**: A — `[Show me]` dismisses like any action button in v1.
+
+---
+
+### Should the feedback body support emphasis, and is the `Hazbot:` prefix always stripped?
+**Context**: The 1B design bolds "Scroll up!", but `Category.feedback` is plain text and every prose line begins with `Hazbot:`.
+**Options considered**:
+- A) Plain text for v1 (no emphasis); always strip the leading `Hazbot:` prefix.
+- B) Support a lightweight emphasis convention now (needs a rule-set data/format change).
+- C) Render `feedback` verbatim including `Hazbot:` (rejected by design).
+
+**Decision**: B (support emphasis now) combined with A's prefix strip — always strip `Hazbot:`; support bold emphasis. Mechanism tracked in the follow-up decisions below.
+
+---
+
+### Popover placement — title vs description, alignment, and offset.
+**Context**: 1B shows body text + button, no separate title, anchored above the button.
+**Options considered**:
+- A) Body as `description` only (no `title`); `side: "top"`, `align: "end"`, default offset.
+- B) Body as `title`.
+- C) Other alignment/offset — confirm against the artboard.
+
+**Decision**: A, with `align: "center"` on the robot-face anchor. The 280px popover is wider than the anchor and Hazbot sits near the right edge, so floating-ui's `shift` pushes the popover left while the arrow keeps pointing at the robot face. (Final tuning: `popoverOffset: 25`.)
+
+---
+
+### Emphasis mechanism — markup convention, generator pass-through, and rendering.
+**Context**: The coachmarks `description` was typed `string` and rendered verbatim (no markdown). Rule-sets are auto-generated, copying feedback prose verbatim, so a markdown convention passes through with no generator edit; the open part was the *rendering*.
+**Options considered**:
+- A) Markdown in the source; widen `description`/`title` to `ReactNode`; wildfire-model parses to nodes.
+- B) Keep `description: string` and add Markdown rendering inside the library (benefits all consumers).
+- C) wildfire-model renders its own body element instead of the library `description`.
+
+**Decision**: B — add Markdown rendering inside the coachmarks library, with a way to disable it; enabled by default. (`description`/`title` stay `string`; the library parses and HTML-escapes.)
+
+---
+
+### What emphasis does the design need, and where does the source markup live?
+**Context**: Only bold ("Scroll up!") appears in the design. The rule-set source is a Google Sheet; adding markup means editing the sheet and regenerating.
+**Options considered**:
+- A) Bold only, via `**…**`, authored in the source sheet; regenerate the rule-set files.
+- B) A small fixed set (bold + italic).
+- C) Full Markdown subset.
+
+**Decision**: A — bold only, `**…**`. (Authoring + regen deferred to the PIs; see Not Yet Implemented.)
+
+---
+
+### Close button (`×`) — the theme hid it, but the design shows a styled blue-circle `×`.
+**Context**: The hazbot theme set `.coachmarks-popover-close-btn { display: none }` (hidden for the earlier AP-64 design). The WM-16 1B design shows a top-right `×` (44×44 target, hover scale-up, select scale-down). Both `×` and the action button dismiss.
+**Options considered**:
+- A) Update the `hazbot` theme to show/style the close button per the design (benefits all hazbot consumers); add `"close"` to `showButtons`.
+- B) Keep the theme hiding it; re-show/style via wildfire-model CSS override.
+- C) Don't render a separate `×`; rely on the action button + Escape.
+
+**Decision**: A — the published theme styles the `×` (white disc, 3px `#0050C4` ring, blue glyph, hover/select states); wildfire-model opts in via `showButtons` including `"close"`.
+
+---
+
+### Are the coachmarks-library changes part of WM-16's "done", or separate work? (Senior Engineer)
+**Context**: The story depends on three sibling-repo changes (Chakra Petch, Markdown with opt-out, close-button styling) plus an npm publish; there is no coachmarks Jira project.
+**Decision**: No separate ticket — WM-16 is the library's first consumer, so the library changes are **in scope for WM-16**. Sequencing: make the library changes → develop via `yalc` → publish to npm → pin the version → merge.
+
+---
+
+### Who resets `ui.showHazbotFeedback` on dismiss, and how does re-open work? (React & MobX)
+**Decision**: Reset `ui.showHazbotFeedback = false` in the engine's `onDestroyed` callback (fires on every teardown route: action button, `×`, Escape) and wire `onCancelRequested → engine.destroy()`. The panel is a MobX `observer`; content is recomputed from a direct `getAnalysisEngine()` read at open time. Verified against the library's `engine.tsx` (action button → `destroy()`; `×`/Escape → `cancel()` → `onCancelRequested`; `onDestroyed` on all paths).
+
+---
+
+### Is the `[Show me]` dead-end acceptable UX for v1? (Product Manager / Student)
+**Decision**: Yes — keep as-is. The action button is generic: its label is parsed per-category (never hardcoded) and in v1 it simply dismisses regardless of label. The walk-through behind `[Show me]` arrives with the follow-on tour story; the feedback prose stays actionable meanwhile. Recorded as a known limitation in Out of Scope.
+
+---
+
+### Acceptance criteria as testable scenarios, and how this is tested given yalc + WebGL. (QA)
+**Decision**: Added explicit Acceptance Criteria + a Testing approach. The panel is unit-tested in jsdom with the coachmarks engine and analysis-engine reads **mocked** (SCSS via `identity-obj-proxy`; the theme's CSS subpath imports stubbed via `moduleNameMapper`), so no WebGL is needed and the library's rendering internals stay out of these tests. The avatar scale-up is a CSS visual target (Playwright vs Zeplin), not unit-asserted.
+
+---
+
+### Category-numbering claims were preset-specific. (Code-verified, PM / data accuracy)
+**Decision**: "Categories 2/3/4 use `[Show me]`" and "Category 5 = success" only describe ruleset-47-shaped sheets. The count and success-id vary (ruleset 42 → 3 categories, success = Cat 3; ruleset 47 → 5, success = Cat 5). Reworded the affected Requirement, decision, and Out-of-Scope lines to be id-agnostic (label parsed per-category, never keyed off a fixed id).
+
+---
+
+### The `matchedCategory === null` AC was unreachable via the rendered button. (Code-verified, QA)
+**Decision**: The button only mounts when a ruleset exists, and Category 1 (`NOT ranSimulation`) matches the empty reading prefix, so the monotone floor is always ≥1 for a loaded ruleset. Marked the `null` guard defensive (first-render transient) and mock-driven, not UI-exercisable.
+
+---
+
+### Unit assertions / how the popover is tested. (Code-verified, QA)
+**Decision**: The popover is portalled via `@floating-ui/react` and the engine mounts in an effect, and jsdom geometry is zeroed, so the library's rendering is not asserted in wildfire-model unit tests. Final approach: mock `createCoachmarksEngine` and assert the consumer wiring (open spec, dismiss callbacks, reopen, `.coached`); placement/rendering are covered by the library's tests + Playwright.
+
+---
+
+### Library-contract precision — action label binds to `doneBtnText`; markdown subset pinned. (Code-verified, library integration)
+**Decision**: A single-step `highlight()` renders `doneBtnText` (the step is last), so the parsed token is passed as `doneBtnText`, not `nextBtnText`. The library had no markdown renderer; since feedback originates in an author-edited sheet, the new parser is a constrained bold-focused subset with HTML escaped (never passed through).

--- a/src/components/hazbot-button.scss
+++ b/src/components/hazbot-button.scss
@@ -37,11 +37,18 @@
     width: 48px;
     height: 48px;
     flex: 0 0 48px;
-    // Anchor for the WM-11 "Large" scale-up: growing from the bottom-left keeps
-    // the robot's feet on the bar baseline while the head grows up-and-out (the
+    // Anchor for the WM-11 "Large" scale-up: growing from the bottom-center keeps
+    // the avatar horizontally centered (no sideways drift over the label) and pins
+    // its bottom edge on the bar baseline while the head grows up-and-out (the
     // ancestor chain is overflow:visible, so it isn't clipped). Inert in WM-6
     // (no transform applied); it's the documented seam for the follow-on story.
-    transform-origin: bottom left;
+    transform-origin: bottom center;
+    // The coachmarks library returns focus to this anchor (the popover's `element`)
+    // when the coach mark closes, setting tabindex="-1" on it. On a keyboard close
+    // (Escape / Enter on ×/Okay) that programmatic focus would draw a :focus-visible
+    // ring on the robot. The avatar isn't a tab stop — keyboard users reach the real
+    // <button>, which keeps its own ring — so suppress the ring here.
+    &:focus { outline: none; }
     // Back / Eyes / Blinks are exported as full 48x48 layers sharing one
     // coordinate space (AP-79), so stack all three at the same origin rather
     // than centering each independently. A single transform on .avatar scales
@@ -88,20 +95,16 @@
   100% { box-shadow: 0 0 0 8px rgba(255, 255, 255, 0); } // -> #FFF, faded out
 }
 
-// ── WM-11 seam (follow-on coach-mark story) ─────────────────────────────────
-// While the coach mark is open, AP-79 shows the button in its "Large" variant:
-// the button grows to 135x69, the #c1daff background fades off, and the avatar
-// scales up and overflows the bar (the ancestor chain is overflow:visible, so it
-// isn't clipped — see bottom-bar.scss). WM-6 only wires the trigger: the click
-// sets `ui.showHazbotFeedback`, which WM-11 maps to a `.coached` class on the
-// wrapper. The structure here already supports it additively — the avatar is an
-// isolated box scaled via a single transform (transform-origin: bottom left
-// above), and the button width/height are overridable. Overrides need
-// `!important` to beat MUI emotion (same source-order reason as the fills above).
-// Sketch (WM-11 to own, not active in WM-6):
-//   .hazbotButtonWrap.coached .hazbotButton {
-//     width: 135px !important; height: 69px !important;
-//     background: transparent !important; border-color: transparent !important;
-//     transition: width .25s, height .25s, background .25s;
-//   }
-//   .hazbotButtonWrap.coached .avatar { transform: scale(1.5); transition: transform .25s; }
+// "Large" state — while the coach-mark feedback panel is open, the wrapper carries
+// the `.coached` class (set from `ui.showHazbotFeedback`). Only the robot avatar
+// scales up and overflows the bar; the button "back" keeps its size, its
+// #c1daff/hover/select fill, and its 1.5px #797979 border. The avatar grows from its
+// bottom-center (transform-origin above) so the robot's feet stay on the bar
+// baseline while the head grows up and out of the (overflow:visible) button — the
+// ancestor chain must stay overflow:visible so the head isn't clipped (see
+// bottom-bar.scss). The coach mark opens only AFTER this transform transition ends
+// (see hazbot-button.tsx) so the popover anchors to the enlarged robot.
+.hazbotButtonWrap.coached .avatar {
+  transform: scale(1.525);
+  transition: transform .25s;
+}

--- a/src/components/hazbot-button.scss
+++ b/src/components/hazbot-button.scss
@@ -37,12 +37,14 @@
     width: 48px;
     height: 48px;
     flex: 0 0 48px;
-    // Anchor for the WM-11 "Large" scale-up: growing from the bottom-center keeps
-    // the avatar horizontally centered (no sideways drift over the label) and pins
-    // its bottom edge on the bar baseline while the head grows up-and-out (the
-    // ancestor chain is overflow:visible, so it isn't clipped). Inert in WM-6
-    // (no transform applied); it's the documented seam for the follow-on story.
+    // Growing from the bottom-center keeps the avatar horizontally centered (no
+    // sideways drift over the label) and pins its bottom edge on the bar baseline
+    // while the head grows up-and-out (the ancestor chain is overflow:visible, so
+    // it isn't clipped). The transition lives here (not only on `.coached`) so both
+    // the open scale-up and the close scale-down animate, and the transform's
+    // `transitionend` (which gates opening the coach mark) fires reliably.
     transform-origin: bottom center;
+    transition: transform 0.25s;
     // The coachmarks library returns focus to this anchor (the popover's `element`)
     // when the coach mark closes, setting tabindex="-1" on it. On a keyboard close
     // (Escape / Enter on ×/Okay) that programmatic focus would draw a :focus-visible
@@ -105,6 +107,5 @@
 // bottom-bar.scss). The coach mark opens only AFTER this transform transition ends
 // (see hazbot-button.tsx) so the popover anchors to the enlarged robot.
 .hazbotButtonWrap.coached .avatar {
-  transform: scale(1.525);
-  transition: transform .25s;
+  transform: scale(1.525); // transition is on the base `.avatar` (animates open + close)
 }

--- a/src/components/hazbot-button.test.tsx
+++ b/src/components/hazbot-button.test.tsx
@@ -73,9 +73,14 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-it("renders the avatar + two-line label", () => {
+it("renders the avatar layers + two-line label", () => {
   renderWithStores();
   expect(screen.getByTestId("hazbot-button")).toHaveTextContent("HazbotAnalysis");
+  // Avatar SVG layers: Back is always present; the default (non-blink) state
+  // shows the open Eyes layer and omits the Blinks layer.
+  expect(screen.getByTestId("hazbot-back")).toBeInTheDocument();
+  expect(screen.getByTestId("hazbot-eyes")).toBeInTheDocument();
+  expect(screen.queryByTestId("hazbot-blinks")).toBeNull();
 });
 
 it("shows the ready/pulse state only when armed && started && !running", () => {

--- a/src/components/hazbot-button.test.tsx
+++ b/src/components/hazbot-button.test.tsx
@@ -1,17 +1,70 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { Provider } from "mobx-react";
-import { HazbotButton } from "./hazbot-button";
+import { HazbotButton, parseFeedback } from "./hazbot-button";
 import { createStores } from "../models/stores";
 import * as logModule from "../log";
+import { getAnalysisEngine } from "../hazbot/wildfire";
+import { computeMatchedCategoryForEngine } from "../hazbot/engine";
+import { createCoachmarksEngine } from "@concord-consortium/coachmarks";
 
-// getAnalysisEngine returns undefined when no URL flags are set (jsdom), so the
-// click path logs matchedCategory: null — exactly the pre-run/no-engine contract.
+// The coachmarks engine and the analysis-engine reads are mocked: these unit tests
+// cover the consumer wiring (what we pass to the engine, the dismiss→flag-reset
+// callbacks, reopen, and the .coached class), not the library's popover rendering
+// (covered by the library's own tests) or anchor placement (Playwright vs Zeplin).
+jest.mock("@concord-consortium/coachmarks", () => ({ createCoachmarksEngine: jest.fn() }));
+jest.mock("../hazbot/wildfire", () => ({
+  ...jest.requireActual("../hazbot/wildfire"),
+  getAnalysisEngine: jest.fn(),
+}));
+jest.mock("../hazbot/engine", () => ({
+  ...jest.requireActual("../hazbot/engine"),
+  computeMatchedCategoryForEngine: jest.fn(),
+}));
+
+const mockGetEngine = getAnalysisEngine as unknown as jest.Mock;
+const mockMatched = computeMatchedCategoryForEngine as unknown as jest.Mock;
+const mockCreateEngine = createCoachmarksEngine as unknown as jest.Mock;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let cmOpts: any;
+let cm: { highlight: jest.Mock; destroy: jest.Mock };
 
 function renderWithStores(stores = createStores()) {
   return { stores, ...render(<Provider stores={stores}><HazbotButton /></Provider>) };
 }
+
+// A minimal analysis engine: the panel reads engine.ruleSet.categories[].feedback.
+function engineWith(categories: { id: number; feedback: string }[]) {
+  return { ruleSet: { categories } } as unknown as ReturnType<typeof getAnalysisEngine>;
+}
+
+// Open the panel: click the button, then let the panel's open-after-scale-up
+// fallback timer (400ms) fire. The panel normally opens on the avatar's transform
+// transitionend, but jsdom doesn't run CSS transitions, so we drive the fallback.
+function openPanel() {
+  jest.useFakeTimers();
+  try {
+    fireEvent.click(screen.getByTestId("hazbot-button"));
+    act(() => { jest.advanceTimersByTime(400); });
+  } finally {
+    jest.useRealTimers();
+  }
+}
+
+function lastHighlightSpec() {
+  const calls = cm.highlight.mock.calls;
+  return calls[calls.length - 1]?.[0];
+}
+
+beforeEach(() => {
+  cm = { highlight: jest.fn(), destroy: jest.fn() };
+  // Default: no engine — matches the pre-engine state the WM-6 tests below rely on.
+  mockGetEngine.mockReset().mockReturnValue(undefined);
+  mockMatched.mockReset();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockCreateEngine.mockReset().mockImplementation((opts: any) => { cmOpts = opts; return cm; });
+});
 
 afterEach(() => {
   // Restore Math.random / log / console.error spies so mock state (e.g. a pinned
@@ -50,6 +103,7 @@ it("click sets showHazbotFeedback, clears the pulse, and logs HazbotButtonClicke
   fireEvent.click(screen.getByTestId("hazbot-button"));
   expect(stores.ui.showHazbotFeedback).toBe(true);
   expect(stores.ui.hazbotPulseArmed).toBe(false);
+  // No engine in this test, so the click logs matchedCategory: null.
   expect(logSpy).toHaveBeenCalledWith("HazbotButtonClicked", { matchedCategory: null });
 });
 
@@ -75,4 +129,104 @@ it("stops the blink loop on unmount (no setState after unmount)", () => {
   act(() => { jest.advanceTimersByTime(5000); });    // any pending timers fire post-unmount
   expect(errSpy).not.toHaveBeenCalled();             // no "set state on unmounted" warning
   jest.useRealTimers();
+});
+
+describe("parseFeedback", () => {
+  it("strips the leading Hazbot: prefix and the trailing [token]", () => {
+    expect(parseFeedback("Hazbot: Hello there [Okay]")).toEqual({ body: "Hello there", label: "Okay" });
+  });
+  it("preserves **bold** markup in the body", () => {
+    expect(parseFeedback("Hazbot: **Remember**, run it [Show me]"))
+      .toEqual({ body: "**Remember**, run it", label: "Show me" });
+  });
+  it("handles a token on its own last line", () => {
+    expect(parseFeedback("Hazbot: line one\n[Got it!]")).toEqual({ body: "line one", label: "Got it!" });
+  });
+  it("returns an empty label when there is no token", () => {
+    expect(parseFeedback("Hazbot: just text")).toEqual({ body: "just text", label: "" });
+  });
+  it("works without a Hazbot: prefix", () => {
+    expect(parseFeedback("Plain body [Hooray!]")).toEqual({ body: "Plain body", label: "Hooray!" });
+  });
+});
+
+describe("Hazbot feedback panel", () => {
+  // The click also calls log(), which routes through the analysis engine's
+  // consume(); the fake engine here has no consume(), and logging is irrelevant to
+  // these tests, so no-op it.
+  beforeEach(() => { jest.spyOn(logModule, "log").mockImplementation(() => undefined); });
+
+  it("opens a coach mark with the matched category's parsed feedback and token label", () => {
+    mockGetEngine.mockReturnValue(
+      engineWith([{ id: 1, feedback: "Hazbot: **Remember**, you need to run the model.\n[Okay]" }]),
+    );
+    mockMatched.mockReturnValue(1);
+    renderWithStores();
+    openPanel();
+
+    expect(mockCreateEngine).toHaveBeenCalledTimes(1);
+    expect(cmOpts.showButtons).toEqual(["next", "close"]);
+    expect(cmOpts.doneBtnText).toBe("Okay");
+    expect(cmOpts.showOutlineRing).toBe(false);
+    const spec = lastHighlightSpec();
+    expect(spec.popover.description).toBe("**Remember**, you need to run the model.");
+    expect(spec.popover.side).toBe("top");
+  });
+
+  it("does not open when there is no engine / matched category (guarded no-op)", () => {
+    mockGetEngine.mockReturnValue(undefined);
+    renderWithStores();
+    openPanel();
+    expect(mockCreateEngine).not.toHaveBeenCalled();
+  });
+
+  it("resets ui.showHazbotFeedback on dismiss via onDestroyed (fires on all routes)", () => {
+    mockGetEngine.mockReturnValue(engineWith([{ id: 1, feedback: "Hazbot: hi [Okay]" }]));
+    mockMatched.mockReturnValue(1);
+    const { stores } = renderWithStores();
+    openPanel();
+    expect(stores.ui.showHazbotFeedback).toBe(true);
+    act(() => { cmOpts.onDestroyed(); });
+    expect(stores.ui.showHazbotFeedback).toBe(false);
+  });
+
+  it("routes ×/Escape (onCancelRequested) through engine.destroy()", () => {
+    mockGetEngine.mockReturnValue(engineWith([{ id: 1, feedback: "Hazbot: hi [Okay]" }]));
+    mockMatched.mockReturnValue(1);
+    renderWithStores();
+    openPanel();
+    act(() => { cmOpts.onCancelRequested(); });
+    expect(cm.destroy).toHaveBeenCalled();
+  });
+
+  it("reopens with the then-current matched category after dismiss", () => {
+    mockGetEngine.mockReturnValue(engineWith([
+      { id: 1, feedback: "Hazbot: Cat one [Okay]" },
+      { id: 2, feedback: "Hazbot: Cat two [Show me]" },
+    ]));
+    mockMatched.mockReturnValue(1);
+    renderWithStores();
+
+    openPanel();
+    expect(lastHighlightSpec().popover.description).toBe("Cat one");
+    expect(cmOpts.doneBtnText).toBe("Okay");
+
+    act(() => { cmOpts.onDestroyed(); });
+    mockMatched.mockReturnValue(2);
+    openPanel();
+    expect(lastHighlightSpec().popover.description).toBe("Cat two");
+    expect(cmOpts.doneBtnText).toBe("Show me");
+  });
+
+  it("toggles the .coached Large-state class with ui.showHazbotFeedback", () => {
+    mockGetEngine.mockReturnValue(engineWith([{ id: 1, feedback: "Hazbot: hi [Okay]" }]));
+    mockMatched.mockReturnValue(1);
+    renderWithStores();
+    const wrap = () => screen.getByTestId("hazbot-button-wrap");
+    expect(wrap().className).not.toMatch(/coached/);
+    openPanel();
+    expect(wrap().className).toMatch(/coached/);
+    act(() => { cmOpts.onDestroyed(); });
+    expect(wrap().className).not.toMatch(/coached/);
+  });
 });

--- a/src/components/hazbot-button.test.tsx
+++ b/src/components/hazbot-button.test.tsx
@@ -96,14 +96,16 @@ it("shows the ready/pulse state only when armed && started && !running", () => {
   expect(wrap().className).not.toMatch(/ready/);
 });
 
-it("click sets showHazbotFeedback, clears the pulse, and logs HazbotButtonClicked", () => {
+it("click clears the pulse and logs HazbotButtonClicked (no engine → panel no-ops)", () => {
   const logSpy = jest.spyOn(logModule, "log");
   const { stores } = renderWithStores();
   act(() => { stores.ui.hazbotPulseArmed = true; });
   fireEvent.click(screen.getByTestId("hazbot-button"));
-  expect(stores.ui.showHazbotFeedback).toBe(true);
+  // No engine in jsdom, so the panel can't open: handleClick sets the flag, then
+  // the guarded effect clears it back (so the button never sticks "Large"). The
+  // pulse is acknowledged and the click logs matchedCategory: null.
+  expect(stores.ui.showHazbotFeedback).toBe(false);
   expect(stores.ui.hazbotPulseArmed).toBe(false);
-  // No engine in this test, so the click logs matchedCategory: null.
   expect(logSpy).toHaveBeenCalledWith("HazbotButtonClicked", { matchedCategory: null });
 });
 
@@ -173,11 +175,13 @@ describe("Hazbot feedback panel", () => {
     expect(spec.popover.side).toBe("top");
   });
 
-  it("does not open when there is no engine / matched category (guarded no-op)", () => {
+  it("does not open when there is no engine / matched category, and resets the flag", () => {
     mockGetEngine.mockReturnValue(undefined);
-    renderWithStores();
+    const { stores } = renderWithStores();
     openPanel();
     expect(mockCreateEngine).not.toHaveBeenCalled();
+    // The guarded no-op clears the flag so the button doesn't stay stuck "Large".
+    expect(stores.ui.showHazbotFeedback).toBe(false);
   });
 
   it("resets ui.showHazbotFeedback on dismiss via onDestroyed (fires on all routes)", () => {

--- a/src/components/hazbot-button.tsx
+++ b/src/components/hazbot-button.tsx
@@ -5,17 +5,35 @@ import { useStores } from "../use-stores";
 import { log } from "../log";
 import { getAnalysisEngine } from "../hazbot/wildfire";
 import { computeMatchedCategoryForEngine } from "../hazbot/engine";
+import { createCoachmarksEngine } from "@concord-consortium/coachmarks";
 import HazbotBack from "../assets/bottom-bar/hazbot-back.svg";
 import HazbotEyes from "../assets/bottom-bar/hazbot-eyes.svg";
 import HazbotBlinks from "../assets/bottom-bar/hazbot-blinks.svg";
 
+import "@concord-consortium/coachmarks/styles/hazbot";
 import css from "./hazbot-button.scss";
 
-// WM-6 Hazbot Analysis button. Presentational `observer` child of the class
-// BottomBar. It does NOT consume useAnalysisEngine(); its only engine touch is
-// the pure computeMatchedCategoryForEngine() call at click time for the log
-// payload. Run-state + the pulse flag come from useStores(); the AP-79 layered
-// avatar (Back + Eyes/Blinks) drives the random blink.
+// Parse a category's `feedback` into the popover body + action-button label. The
+// avatar is the speaker, so strip the leading "Hazbot:" prefix; the single trailing
+// bracket token (e.g. `[Okay]`, `[Show me]`, `[Hooray!]`) becomes the button label.
+// Rule-sets carry exactly one token, on the last line. Bold (`**…**`) is left intact
+// in the body for the coachmarks library to render. Exported for unit testing.
+export function parseFeedback(raw: string): { body: string; label: string } {
+  let text = raw.replace(/^\s*Hazbot:\s*/, "");
+  const token = text.match(/\[([^\]]+)\]\s*$/);
+  const label = token ? token[1].trim() : "";
+  if (token) text = text.slice(0, token.index);
+  return { body: text.trim(), label };
+}
+
+// The Hazbot Analysis button (bottom bar), a MobX `observer` child of BottomBar.
+// Clicking it opens the coach-mark feedback panel (the effect below) and logs the
+// matched category. It reads the analysis engine directly via getAnalysisEngine() +
+// computeMatchedCategoryForEngine() — a pure read at click/open time — rather than
+// the reactive useAnalysisEngine() hook, since the matched category is only needed
+// at those moments, not live while the popover is open. Run-state + the pulse flag
+// come from useStores(); the layered avatar (Back + Eyes/Blinks) drives the random
+// blink.
 export const HazbotButton = observer(function HazbotButton() {
   const { ui, simulation } = useStores();
 
@@ -49,8 +67,73 @@ export const HazbotButton = observer(function HazbotButton() {
   const pulsing =
     ui.hazbotPulseArmed && simulation.simulationStarted && !simulation.simulationRunning;
 
+  // Coach-mark feedback panel. When ui.showHazbotFeedback flips true, open the
+  // styled `hazbot`-theme coach mark anchored to the robot face (avatarRef → popover
+  // centered over it, arrow pointing at it). The matched category's feedback is
+  // parsed into the popover body (leading "Hazbot:" stripped) and the action-button
+  // label (the trailing bracket token → doneBtnText), shown alongside the close (×)
+  // button. Every dismiss route (action button → onDestroyed; ×/Escape →
+  // onCancelRequested → destroy() → onDestroyed) resets ui.showHazbotFeedback, so a
+  // re-click reopens with the then-current category. `ringElement` targets the outer
+  // button for the optional outline ring (disabled here via showOutlineRing: false).
+  const avatarRef = useRef<HTMLSpanElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (!ui.showHazbotFeedback || !avatarRef.current) return;
+    const engine = getAnalysisEngine();
+    const matched = engine ? computeMatchedCategoryForEngine(engine) : null;
+    const feedback =
+      engine?.ruleSet?.categories.find((c) => c.id === matched)?.feedback ?? "";
+    if (!feedback) return; // null-guard: no rule-set / no matched category
+    const { body, label } = parseFeedback(feedback);
+    const avatar = avatarRef.current;
+    let destroyed = false;
+    let cm: ReturnType<typeof createCoachmarksEngine> | null = null;
+    const open = () => {
+      if (destroyed) return;
+      cm = createCoachmarksEngine({
+        showButtons: ["next", "close"],
+        doneBtnText: label || undefined, // single-step highlight renders doneBtnText
+        showOutlineRing: false, // no outline ring on this panel
+        popoverOffset: 25, // raise the popover for a gap between the arrow tip and the robot
+        // Arrow geometry per the Hazbot coach-mark design; strokeWidth 3 matches the
+        // hazbot theme's 3px popover border.
+        arrow: { width: 36, height: 18, strokeWidth: 3 },
+        onCancelRequested: () => { if (!destroyed) cm?.destroy(); },
+        onDestroyed: () => { destroyed = true; ui.showHazbotFeedback = false; },
+      });
+      cm.highlight({
+        element: avatar,                          // anchor: popover centered over the robot
+        ringElement: buttonRef.current ?? undefined, // ring target (inert; ring disabled)
+        popover: { side: "top", align: "center", description: body },
+      });
+    };
+    // Open AFTER the `.coached` scale-up transition settles: a CSS transform does
+    // not fire floating-ui's ResizeObserver, so opening mid-grow would anchor to
+    // the un-scaled robot. Wait for the avatar's transform transitionend (fallback
+    // timeout in case it doesn't fire) so the popover offsets by the enlarged size.
+    let opened = false;
+    const openOnce = () => {
+      if (opened) return; // whichever trigger fires first wins; the other no-ops
+      opened = true;
+      open();
+    };
+    const onTransitionEnd = (e: TransitionEvent) => {
+      if (e.propertyName === "transform") openOnce();
+    };
+    avatar.addEventListener("transitionend", onTransitionEnd);
+    const fallbackId = setTimeout(openOnce, 400);
+    return () => {
+      destroyed = true;
+      avatar.removeEventListener("transitionend", onTransitionEnd);
+      clearTimeout(fallbackId);
+      cm?.destroy();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ui.showHazbotFeedback]);
+
   const handleClick = () => {
-    // Sibling-panel contract (WM-11 reads this); WM-6 does not render the panel.
+    // Open the feedback panel (the effect above renders it off this flag).
     ui.showHazbotFeedback = true;
     // Acknowledge the run — stop pulsing until the next run completes.
     ui.hazbotPulseArmed = false;
@@ -71,16 +154,26 @@ export const HazbotButton = observer(function HazbotButton() {
     // The `ready` class on the wrapper gates the pulse — a box-shadow halo on the
     // button, matching the behavior + width of the MODA "Update Code" button's
     // pulse-shadow (question-interactives/packages/agent-simulation).
-    <div className={`${css.hazbotButtonWrap} ${pulsing ? css.ready : ""}`} data-testid="hazbot-button-wrap">
+    <div
+      className={`${css.hazbotButtonWrap} ${pulsing ? css.ready : ""} ${ui.showHazbotFeedback ? css.coached : ""}`}
+      data-testid="hazbot-button-wrap"
+    >
       <Button
+        ref={buttonRef}
         className={css.hazbotButton}
         data-testid="hazbot-button"
         onClick={handleClick}
+        // Don't take focus on mouse press: when the coach mark closes the library
+        // restores focus to whatever was focused on open, and a focused button
+        // would show its focus-visible ring. preventDefault on mousedown blocks the
+        // focus-on-click without blocking the click itself (onClick still fires) or
+        // keyboard focus/activation.
+        onMouseDown={(e) => e.preventDefault()}
         disableRipple={true}
         disableTouchRipple={true}
       >
         <span className={css.inner}>
-          <span className={css.avatar}>
+          <span className={css.avatar} ref={avatarRef}>
             <HazbotBack />
             {blink
               ? <HazbotBlinks data-testid="hazbot-blinks" />

--- a/src/components/hazbot-button.tsx
+++ b/src/components/hazbot-button.tsx
@@ -84,7 +84,13 @@ export const HazbotButton = observer(function HazbotButton() {
     const matched = engine ? computeMatchedCategoryForEngine(engine) : null;
     const feedback =
       engine?.ruleSet?.categories.find((c) => c.id === matched)?.feedback ?? "";
-    if (!feedback) return; // null-guard: no rule-set / no matched category
+    if (!feedback) {
+      // Nothing to show (no engine / no matched category / empty feedback). Clear
+      // the flag so the button doesn't stay stuck in its "Large" coached state and
+      // a later click can re-trigger the effect.
+      ui.showHazbotFeedback = false;
+      return;
+    }
     const { body, label } = parseFeedback(feedback);
     const avatar = avatarRef.current;
     let destroyed = false;

--- a/src/components/hazbot-button.tsx
+++ b/src/components/hazbot-button.tsx
@@ -180,7 +180,7 @@ export const HazbotButton = observer(function HazbotButton() {
       >
         <span className={css.inner}>
           <span className={css.avatar} ref={avatarRef}>
-            <HazbotBack />
+            <HazbotBack data-testid="hazbot-back" />
             {blink
               ? <HazbotBlinks data-testid="hazbot-blinks" />
               : <HazbotEyes data-testid="hazbot-eyes" />}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -11,3 +11,5 @@ declare module "*.png" {
 }
 declare module "shutterbug";
 declare module "chartjs-plugin-annotation";
+// coachmarks hazbot theme stylesheet (side-effect CSS import via package exports).
+declare module "@concord-consortium/coachmarks/styles/hazbot";


### PR DESCRIPTION
## Summary

Adds the Hazbot feedback panel (WM-16): clicking the **Hazbot Analysis** button opens a `hazbot`-theme coach mark above it, rendering the analysis engine's current matched-category feedback.

- Body = the matched category's `feedback` with the leading `Hazbot:` prefix stripped; the trailing bracket token (`[Okay]`, `[Show me]`, …) becomes the action-button label. Bold (`**…**`) renders via the library's markdown subset.
- The close (×) button, the action button, and Escape all dismiss; every route resets `ui.showHazbotFeedback`, so a re-click reopens with the then-current category.
- While open, the button shows its "Large" state (only the robot avatar scales up); the robot's focus ring is suppressed on close.

## Library dependency

Consumes the newly published `@concord-consortium/coachmarks@0.0.1-pre.7` (styled close button, Chakra Petch description font, default-on markdown bold, plus the `main`/`module`/`types` packaging fields so it type-checks under classic `moduleResolution: node`). The library changes were developed against this branch via yalc, then published.

## Tests

- Unit tests for `parseFeedback` and the panel wiring with the coachmarks engine + analysis-engine reads mocked (open spec, dismiss/reopen, null guard, `.coached` toggle).
- Full Jest suite green (666/666).

## Notes

- Bold **authoring** in the source Google Sheet (+ ruleset regen) is deferred to the PIs; the rendering path is implemented and verified.
- Based off `WM-6-add-hazbot-button`.

Spec: `specs/WM-16-hazbot-feedback-panel.md`
Jira: https://concord-consortium.atlassian.net/browse/WM-16