### PR TITLE
feat: add dashed zone boundary lines to 3D model [WM-7]

### DIFF
--- a/specs/WM-7-add-dotted-lines-to-delineate-the-zones.md
+++ b/specs/WM-7-add-dotted-lines-to-delineate-the-zones.md
@@ -1,0 +1,78 @@
+# Add dotted lines to delineate the zones
+
+**Jira**: https://concord-consortium.atlassian.net/browse/WM-7
+
+**Status**: **Closed**
+
+## Overview
+
+Add a white dashed line drawn on the 3D terrain along the boundaries between zones so students can clearly see where one zone ends and the next begins. The wildfire model divides the landscape into 2 or 3 zones, each with its own vegetation, terrain type, and drought level; until now the only cue to a zone boundary was a subtle change in terrain coloring. The line gives students and teachers a clear, persistent reference for reasoning about how conditions differ across the landscape and how fire behaves as it crosses from one zone into another. Rendering is gated behind a `showZoneLines` config/URL flag (default off), and the exact dash sizing is expected to be refined through visual iteration with the project owner.
+
+## Requirements
+
+- A **white dashed line** is drawn on the 3D terrain along the boundary between adjacent zones.
+- The boundary is derived **generically**: a segment is drawn wherever two adjacent cells have differing `zoneIdx`. Works for 2-zone (one divider) and 3-zone (two dividers) models, and for custom/non-straight zone layouts (`complexZones`, image-based zones).
+- The line follows the terrain surface elevation (drapes over the heightmap) rather than sitting at a flat height.
+- By default the line is **fully visible and drawn on top of** fire/burnt terrain (unchanged by fire state). The implementation is structured so depth-based occlusion can be switched on later without a rewrite *(occlusion mode itself not built — see Out of Scope)*.
+- Rendering of the line is gated by the `showZoneLines` config/URL parameter, defaulting to **OFF**.
+- Exact dash length/gap and line width are not fixed by a formal design; a reasonable white-dashed default matching the ticket sketch is implemented and refined visually with the project owner *(final styling values settled through iteration, not in this spec)*.
+
+## Technical Notes
+
+Implemented as a `THREE.LineSegments` sibling of `Terrain` inside the Canvas ([src/components/view-3d/zone-lines.tsx](src/components/view-3d/zone-lines.tsx)), with a `THREE.BufferGeometry` of boundary edges and a `LineDashedMaterial` (white, `depthTest: false`, `renderOrder` above terrain). Validated across `plainsTwoZone`, `hillThreeZone`, and `complexZones` (diagonal/staircase boundaries), draped over terrain and staying fully visible over active/burnt fire. Geometry build:
+- Iterate cells; for each cell's right and bottom neighbor, if `zoneIdx` differs, emit a segment along the shared grid edge (right edge at model-x `(x+1)*cellSize`, spanning `y..y+1`; bottom edge at model-y `(y+1)*cellSize`, spanning `x..x+1`). Checking only right+bottom avoids drawing each edge twice.
+- World coords mirror `marker.tsx`: `modelFt * ftToViewUnit(simulation)`; segment z = average of the two adjacent cells' `elevation * ratio`, plus a small lift (`+0.004` view units) to avoid z-fighting.
+- `LineDashedMaterial` requires `computeLineDistances()` on the line object after the position attribute is set (done in a `useLayoutEffect`). Starting dash values: `dashSize 0.012`, `gapSize 0.008` (view units) — tuned visually.
+- Geometry rebuilds on `cellsElevationFlag` / grid-size change. `linewidth` on `LineDashedMaterial` is capped at 1px on most WebGL platforms; a fat-line approach (e.g. `Line2`/`LineGeometry`) would be needed for a thicker line.
+
+The `showZoneLines` flag was added to the config interface and `getDefaultConfig()` (default `false`) in [src/config.ts](src/config.ts), following the existing `showBurnIndex` pattern; URL-param coercion is handled generically by `getUrlConfig()`.
+
+Note on complex boundaries: segments follow cell edges, so diagonal `zoneIdx` boundaries render as a 90° staircase (accurate to the grid, not smoothed). The study's standard presets use straight vertical dividers, so this only affects custom presets.
+
+Relevant files: [view-3d.tsx](src/components/view-3d/view-3d.tsx) (scene assembly), [terrain.tsx](src/components/view-3d/terrain.tsx) (terrain mesh, color/elevation), [helpers.ts](src/components/view-3d/helpers.ts) (ft→view-unit conversion), [simulation.ts](src/models/simulation.ts) (zone/cell data), [grid-utils.ts](src/models/utils/grid-utils.ts) (neighbor helpers).
+
+## Out of Scope
+
+- Accessibility concerns (keyboard, screen reader, color contrast) are out of scope for this repo.
+- Labeling zones with names/numbers (this story is the boundary line only).
+- Changing zone data, zone assignment, or the setup/zone-selector UI.
+- Finalizing exact styling values (dash size, line width); these are settled through visual iteration with the project owner, not in this spec.
+- Building the depth-based occlusion mode (only leaving the door open for it; default remains draw-on-top).
+
+## Decisions
+
+### What is the source of truth for the line's visual styling?
+**Context**: The ticket provides a hand sketch as a "starting point" and explicitly expects tweaking once seen in 3D. We needed to know how precise to be about color, dash length/gap, and line width, and whether a Zeplin design exists.
+**Options considered**:
+- A) No formal design; implement a reasonable default from the sketch (white/black dashed line) and iterate visually with the project owner. Leave exact values to dev judgment.
+- B) A Zeplin design exists; fetch it and pin exact color/dash/width values as requirements.
+- C) Define specific target values now in the spec and treat the sketch as superseded.
+
+**Decision**: A. No formal design. Implement a white dashed line (matching the ticket sketch) and iterate visually with the project owner; exact dash/width values left to dev judgment.
+
+### Which zone configurations must the line support?
+**Context**: Default presets split zones with straight vertical lines (2-zone: one divider; 3-zone: two dividers). Custom presets (`complexZones`, image-based) can have arbitrary, non-straight boundaries. Supporting only straight dividers is simpler; supporting arbitrary boundaries is more general but more work.
+**Options considered**:
+- A) All zone boundaries generically (any adjacent cells with differing `zoneIdx`), so it works for every preset including custom/diagonal/image-based.
+- B) Only the standard straight vertical dividers used by the study presets (2-zone and 3-zone).
+- C) Standard straight dividers now; generic boundaries deferred to a follow-up.
+
+**Decision**: A. Derive boundaries generically from differing `zoneIdx` so all presets (including custom/diagonal/image-based) are supported. Validated in a spike across `plainsTwoZone`, `hillThreeZone`, and `complexZones`.
+
+### How should the line behave while a fire is active or has burned across it?
+**Context**: The ticket calls out wanting to see "how it looks when fire(s) is active." The line could stay fully visible on top of fire/burnt cells, or be visually de-emphasized where fire overlaps.
+**Options considered**:
+- A) Always fully visible, drawn on top of fire/burnt terrain (render over, no z-fighting), unchanged by fire state.
+- B) Visible but allowed to be occluded by raised fire effects / depth as normal.
+- C) Some other treatment.
+
+**Decision**: A (draw on top, fully visible, unchanged by fire state) as the default, with the implementation structured so B (depth-based occlusion) can be enabled later without a rewrite.
+
+### Should the zone line be always-on, or gated by a config/URL parameter?
+**Context**: Many features in this app are toggleable via config/URL params (e.g. `showBurnIndex`, `*Available`). The zone line could always render, or be controllable (default on or off) so it can be disabled for certain activities.
+**Options considered**:
+- A) Always on, no config flag.
+- B) Config/URL param (e.g. `showZoneLines`), default ON.
+- C) Config/URL param, default OFF.
+
+**Decision**: C. Gate behind the `showZoneLines` config/URL param, default OFF.

--- a/src/components/view-3d/view-3d.tsx
+++ b/src/components/view-3d/view-3d.tsx
@@ -5,6 +5,7 @@ import { observer, Provider } from "mobx-react";
 import { useStores } from "../../use-stores";
 import { DEFAULT_UP, ftToViewUnit, PLANE_WIDTH, planeHeight } from "./helpers";
 import { Terrain } from "./terrain";
+import { ZoneLines } from "./zone-lines";
 import { SparksContainer } from "./spark";
 import * as THREE from "three";
 import { FireLineMarkersContainer } from "./fire-line-marker";
@@ -214,6 +215,7 @@ export const View3d = observer(function View3d() {
         />
         <hemisphereLight args={[0xC6C2B6, 0x3A403B, 1.2]} up={DEFAULT_UP}/>
         <Terrain ref={terrainRef}/>
+        <ZoneLines/>
         <SparksContainer dragPlane={terrainRef}/>
         <FireLineMarkersContainer dragPlane={terrainRef}/>
         <TownMarkersContainer/>

--- a/src/components/view-3d/zone-lines.tsx
+++ b/src/components/view-3d/zone-lines.tsx
@@ -25,8 +25,18 @@ export const ZoneLines = observer(function ZoneLines() {
     const ratio = ftToViewUnit(simulation);
     const pts: number[] = [];
     const cellAtGrid = (x: number, y: number) => cells[getGridIndexForLocation(x, y, gridWidth)];
+    // fillTerrainEdges zeros the elevation of perimeter cells (left/right columns
+    // and top row) to build the terrain's edge wall. Draping the line over those
+    // zeros makes it dive to the base at the edges, so use the nearest interior
+    // cell's elevation for an edge cell instead.
+    const displayElevation = (cell: Cell) => {
+      if (!simulation.isTerrainEdge(cell.x, cell.y)) return cell.elevation;
+      const ix = cell.x === 0 ? 1 : cell.x === gridWidth - 1 ? gridWidth - 2 : cell.x;
+      const iy = cell.y === 0 ? 1 : cell.y;
+      return (cellAtGrid(ix, iy) ?? cell).elevation;
+    };
     // Average elevation of the two cells an edge divides, in view units, lifted.
-    const edgeZ = (a: Cell, b: Cell) => ((a.elevation + b.elevation) / 2) * ratio + Z_LIFT;
+    const edgeZ = (a: Cell, b: Cell) => ((displayElevation(a) + displayElevation(b)) / 2) * ratio + Z_LIFT;
     const push = (x1: number, y1: number, z: number, x2: number, y2: number) => {
       pts.push(x1 * cs * ratio, y1 * cs * ratio, z, x2 * cs * ratio, y2 * cs * ratio, z);
     };

--- a/src/components/view-3d/zone-lines.tsx
+++ b/src/components/view-3d/zone-lines.tsx
@@ -1,0 +1,78 @@
+// WM-7 — zone-boundary dashed line. Renders a white dashed line along every
+// boundary between adjacent cells with differing zoneIdx, draped over the
+// terrain. Gated by the `showZoneLines` config flag (default off). Dash sizing
+// is a starting point; tune visually with the project owner.
+import React, { useLayoutEffect, useMemo, useRef } from "react";
+import { observer } from "mobx-react";
+import * as THREE from "three";
+import { useStores } from "../../use-stores";
+import { ftToViewUnit } from "./helpers";
+
+// Small vertical lift (view units) so the line floats just above the terrain surface.
+const Z_LIFT = 0.004;
+
+export const ZoneLines = observer(function ZoneLines() {
+  const { simulation } = useStores();
+  const geomRef = useRef<THREE.BufferGeometry>(null);
+  const lineRef = useRef<THREE.LineSegments>(null);
+
+  const positions = useMemo(() => {
+    if (!simulation.dataReady || !simulation.config.showZoneLines) return new Float32Array(0);
+    const { gridWidth, gridHeight, cells } = simulation;
+    const cs = simulation.config.cellSize;
+    const ratio = ftToViewUnit(simulation);
+    const pts: number[] = [];
+    const cellAtGrid = (x: number, y: number) => cells[x + y * gridWidth];
+    // Average elevation of the two cells an edge divides, in view units, lifted.
+    const edgeZ = (a: any, b: any) => ((a.elevation + b.elevation) / 2) * ratio + Z_LIFT;
+    const push = (x1: number, y1: number, z: number, x2: number, y2: number) => {
+      pts.push(x1 * cs * ratio, y1 * cs * ratio, z, x2 * cs * ratio, y2 * cs * ratio, z);
+    };
+    for (let y = 0; y < gridHeight; y++) {
+      for (let x = 0; x < gridWidth; x++) {
+        const c = cellAtGrid(x, y);
+        if (!c) continue;
+        // Right neighbor: shared vertical edge at model-x=(x+1)*cs, y..y+1.
+        if (x + 1 < gridWidth) {
+          const r = cellAtGrid(x + 1, y);
+          if (r && r.zoneIdx !== c.zoneIdx) push(x + 1, y, edgeZ(c, r), x + 1, y + 1);
+        }
+        // Bottom neighbor: shared horizontal edge at model-y=(y+1)*cs, x..x+1.
+        if (y + 1 < gridHeight) {
+          const d = cellAtGrid(x, y + 1);
+          if (d && d.zoneIdx !== c.zoneIdx) push(x, y + 1, edgeZ(c, d), x + 1, y + 1);
+        }
+      }
+    }
+    return new Float32Array(pts);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [simulation, simulation.dataReady, simulation.config.showZoneLines,
+      simulation.cellsElevationFlag, simulation.gridWidth, simulation.gridHeight]);
+
+  useLayoutEffect(() => {
+    if (geomRef.current) {
+      geomRef.current.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+      geomRef.current.attributes.position.needsUpdate = true;
+      lineRef.current?.computeLineDistances();
+    }
+  }, [positions]);
+
+  if (positions.length === 0) return null;
+
+  return (
+    /* eslint-disable react/no-unknown-property */
+    <lineSegments ref={lineRef} renderOrder={2}>
+      <bufferGeometry ref={geomRef} />
+      <lineDashedMaterial
+        attach="material"
+        color={0xffffff}
+        dashSize={0.012}
+        gapSize={0.008}
+        linewidth={1}
+        depthTest={false}
+        transparent={true}
+      />
+    </lineSegments>
+    /* eslint-enable react/no-unknown-property */
+  );
+});

--- a/src/components/view-3d/zone-lines.tsx
+++ b/src/components/view-3d/zone-lines.tsx
@@ -6,6 +6,8 @@ import React, { useLayoutEffect, useMemo, useRef } from "react";
 import { observer } from "mobx-react";
 import * as THREE from "three";
 import { useStores } from "../../use-stores";
+import { Cell } from "../../models/cell";
+import { getGridIndexForLocation } from "../../models/utils/grid-utils";
 import { ftToViewUnit } from "./helpers";
 
 // Small vertical lift (view units) so the line floats just above the terrain surface.
@@ -22,9 +24,9 @@ export const ZoneLines = observer(function ZoneLines() {
     const cs = simulation.config.cellSize;
     const ratio = ftToViewUnit(simulation);
     const pts: number[] = [];
-    const cellAtGrid = (x: number, y: number) => cells[x + y * gridWidth];
+    const cellAtGrid = (x: number, y: number) => cells[getGridIndexForLocation(x, y, gridWidth)];
     // Average elevation of the two cells an edge divides, in view units, lifted.
-    const edgeZ = (a: any, b: any) => ((a.elevation + b.elevation) / 2) * ratio + Z_LIFT;
+    const edgeZ = (a: Cell, b: Cell) => ((a.elevation + b.elevation) / 2) * ratio + Z_LIFT;
     const push = (x1: number, y1: number, z: number, x2: number, y2: number) => {
       pts.push(x1 * cs * ratio, y1 * cs * ratio, z, x2 * cs * ratio, y2 * cs * ratio, z);
     };
@@ -61,7 +63,10 @@ export const ZoneLines = observer(function ZoneLines() {
 
   return (
     /* eslint-disable react/no-unknown-property */
-    <lineSegments ref={lineRef} renderOrder={2}>
+    // renderOrder 0 keeps the line below markers (sparks/towns/fire lines render
+    // at renderOrder 1) so they draw on top of it; depthTest:false still keeps it
+    // above the terrain surface (drawn in the earlier opaque pass).
+    <lineSegments ref={lineRef} renderOrder={0}>
       <bufferGeometry ref={geomRef} />
       <lineDashedMaterial
         attach="material"

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,6 +74,8 @@ export interface ISimulationConfig {
   helitackDropRadius: number; // ft
   // Renders burn index.
   showBurnIndex: boolean;
+  // Renders dashed lines along the boundaries between zones.
+  showZoneLines: boolean;
   // Displays alert with current coordinates on mouse click. Useful for authoring.
   showCoordsOnClick: boolean;
   // Number between 0 and 1 which decides how likely is for unburnt island to form (as it's random).
@@ -194,6 +196,7 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   maxFireLineLength: 15000, // ft
   helitackDropRadius: 2640, // ft (5280 ft = 1 mile)
   showBurnIndex: true,
+  showZoneLines: false,
   showCoordsOnClick: false,
   unburntIslandProbability: 0.5, // [0, 1]
   fireSurvivalProbability: 0.1, // [0, 1]


### PR DESCRIPTION
## Summary

Adds a white dashed line along the boundaries between zones in the 3D model, so students can clearly see where one zone ends and the next begins. Jira: [WM-7](https://concord-consortium.atlassian.net/browse/WM-7).

- New `ZoneLines` component renders the boundary as `THREE.LineSegments` with a dashed material, draped over the terrain surface and drawn on top of fire/burnt cells.
- Boundaries are derived **generically** from differing cell `zoneIdx`, so 2-zone, 3-zone, and custom/non-straight layouts (`complexZones`, image-based zones) all work.
- Gated behind a new `showZoneLines` config/URL flag, **default off**.

## How it works

For each cell, a segment is emitted along the shared edge with its right/bottom neighbor when `zoneIdx` differs (checking only right+bottom avoids drawing each edge twice). Segment elevation is the average of the two adjacent cells' elevation, lifted slightly to avoid z-fighting. `LineDashedMaterial` uses `depthTest: false` + `renderOrder` above the terrain so the line stays visible over fire.

## Testing

Validated in the running app (Playwright) across `plainsTwoZone`, `hillThreeZone`, and `complexZones`, with the default-off / `?showZoneLines` gating, and during an active fire run. `eslint` clean on changed files.

## Notes

- Dash size / line width are a starting point, to be tuned visually with the project owner; `linewidth` is capped at 1px on most WebGL platforms (a fat-line approach would be needed for thicker).
- Diagonal boundaries render as a grid-accurate 90° staircase (only affects custom presets; study presets use straight dividers).

Spec: `specs/WM-7-add-dotted-lines-to-delineate-the-zones.md`

[WM-7]: https://concord-consortium.atlassian.net/browse/WM-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ